### PR TITLE
Forward include_nsfw flag to esearch-api

### DIFF
--- a/src/server/handlers/search-api.ts
+++ b/src/server/handlers/search-api.ts
@@ -5,16 +5,17 @@ import config from "../../config";
 import {baseApiRequest, pipe} from "../util";
 
 export const search = async (req: express.Request, res: express.Response) => {
-    const {q, sort, hide_low, since, scroll_id, votes} = req.body;
+    const {q, sort, hide_low, since, scroll_id, votes, include_nsfw} = req.body;
 
     const url = `${config.searchApiAddr}/search`;
     const headers = {'Authorization': config.searchApiToken};
 
-    const payload: { q: string, sort: string, hide_low: string, since?: string, scroll_id?: string, votes?: number } = {q, sort, hide_low};
+    const payload: { q: string, sort: string, hide_low: string, since?: string, scroll_id?: string, votes?: number, include_nsfw?: number } = {q, sort, hide_low};
 
     if (since) payload.since = since;
     if (scroll_id) payload.scroll_id = scroll_id;
     if (votes) payload.votes = votes;
+    if (include_nsfw) payload.include_nsfw = include_nsfw;
 
     pipe(baseApiRequest(url, "POST", headers, payload), res);
 }


### PR DESCRIPTION
## Summary

- Pass the optional `include_nsfw` flag from clients through to the esearch-api `/search` endpoint
- Default behavior is unchanged: when omitted, esearch-api filters NSFW results

The esearch-api now applies an always-on NSFW filter (combining `is_nsfw` and the `nsfw` tag). The frontend exposes a "Show NSFW content" toggle that sets `include_nsfw=1` when the user opts in. This proxy was dropping the field, so the toggle had no effect.

## Test plan

- [ ] POST /search with include_nsfw=1 → forwarded
- [ ] POST /search without the field → request unchanged
- [ ] Existing q, sort, hide_low, since, scroll_id, votes still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now support NSFW content filtering options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-api/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->