### PR TITLE
Guard promoted-entries against non-array upstream body

### DIFF
--- a/src/server/helper.ts
+++ b/src/server/helper.ts
@@ -427,6 +427,13 @@ export const fetchPromotedEntries = async (limit=200,short_content=0): Promise<E
     // fetch list from api
     const list: { author: string, permlink: string, post_data?: Entry }[] = (await apiRequest(`promoted-posts?limit=${limit}&short_content=${short_content}`, 'GET')).data;
 
+    // baseApiRequest treats any HTTP status as success, so when the upstream is
+    // unhealthy `data` can be a non-array error body. Guard before sorting so we
+    // degrade to no promotions instead of throwing "sort is not a function".
+    if (!Array.isArray(list)) {
+        return [];
+    }
+
     // random sort & random pick 18 (6*3)
     const promoted = list.sort(() => Math.random() - 0.5).filter((x, i) => i < 18);
 


### PR DESCRIPTION
## Problem
When the promoted-posts upstream is unhealthy, `fetchPromotedEntries` logs `warn: failed to fetch promoted TypeError: r.sort is not a function` on every poll.

Root cause: `baseApiRequest` uses `validateStatus: () => true`, so a non-2xx upstream response no longer throws — it resolves with the error body as `data`. `fetchPromotedEntries` then calls `.sort()` on that non-array value and throws. The outer `try/catch` in `getPromotedEntries` swallows it to `[]`, so it isn't user-facing, but it produces continuous error spam during any upstream blip and obscures the real cause.

## Fix
Treat a non-array body as "no promotions" (`return []`) before sorting, so the endpoint degrades gracefully and quietly while the upstream recovers. `getPromotedEntries` only caches non-empty results, so it keeps retrying on the next request.

## Notes
Companion to #17 (fail-fast upstream timeouts) — same `validateStatus: () => true` behavior change surfaced both. No behavior change on the happy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when the promotional content service returned unexpected responses, improving app stability during upstream service issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-api/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->