### PR TITLE
Add /private-api/quests passthrough

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2235,6 +2235,11 @@ export const portfolio = async (req: express.Request, res: express.Response) => 
     pipe(apiRequest(u, "GET"), res);
 };
 
+export const quests = async (req: express.Request, res: express.Response) => {
+    const { username } = req.body;
+    pipe(apiRequest(`users/${username}/quests`, "GET"), res);
+};
+
 export const createAccount = async (req: express.Request, res: express.Response) => {
     const { username, email, referral } = req.body;
 

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -68,6 +68,7 @@ server
     .post("^/private-api/comment-history$", privateApi.commentHistory)
     .post("^/private-api/points$", privateApi.points)
     .post("^/private-api/point-list$", privateApi.pointList)
+    .post("^/private-api/quests$", privateApi.quests)
     .post("^/private-api/account-create$", privateApi.createAccount)
     .post("^/private-api/account-create-friend$", privateApi.createAccountFriend)
     .post("^/private-api/subscribe$", privateApi.subscribeNewsletter)


### PR DESCRIPTION
## What

Adds a `POST /private-api/quests` passthrough to the ePoints `users/<username>/quests` endpoint, backing the daily-quests tracker SDK module + UI.

## Details

- New `quests` handler mirrors the existing `points` handler — forwards `username` from the request body.
- Registered as `POST /private-api/quests`.
- Read-only passthrough; same client gate as `points`/`point-list` (no extra auth — quest progress is the user's own public activity counts).

Pairs with ecency/ePoints#10 (endpoint) and the `@ecency/sdk` quests module (vision-next). Deploy after the ePoints endpoint is live.