### PR TITLE
Fetch portfolio global props & account via Hive RPC instead of external gateway

### DIFF
--- a/src/server/handlers/hive-explorer.ts
+++ b/src/server/handlers/hive-explorer.ts
@@ -1,18 +1,34 @@
-import { baseApiRequest, parseAsset, parseToken } from '../util';
+import { Client } from '@hiveio/dhive';
+import { parseToken } from '../util';
 
 
-const BASE_URL = 'https://hivexplorer.com/api';
+// Fetch chain data directly from Hive RPC nodes (dhive handles failover across the
+// list, preferring our own node first) instead of routing through an external REST
+// gateway, which is a single point of failure for the portfolio endpoints.
+const client = new Client([
+    "https://hapi.ecency.com",
+    "https://api.hive.blog",
+    "https://techcoderx.com",
+    "https://api.deathwing.me",
+    "https://rpc.mahdiyari.info",
+    "https://hive-api.arcange.eu",
+    "https://api.openhive.network",
+    "https://hiveapi.actifit.io",
+    "https://hive-api.3speak.tv",
+    "https://api.syncad.com",
+    "https://api.c0ff33a.uk"
+], {
+    timeout: 2000,
+    failoverThreshold: 2,
+    consoleOnFailover: false
+});
 
 
 export const fetchGlobalProps = async () => {
-    let globalDynamic;
+    let globalDynamic: any;
 
     try {
-        const _globalPropsUrl = `${BASE_URL}/get_dynamic_global_properties`;
-
-        const globalDynamicResp = await baseApiRequest(_globalPropsUrl, 'GET');
-
-        globalDynamic = globalDynamicResp.data;
+        globalDynamic = await client.database.getDynamicGlobalProperties();
 
         if (!globalDynamic) {
             throw new Error("Invalid global props data")
@@ -102,10 +118,8 @@ export const fetchGlobalProps = async () => {
 */
 export const getAccount = async (username: string) => {
     try {
-        const url = `${BASE_URL}/get_accounts?names=["${username}"]`;
-        const response = await baseApiRequest(url, 'GET');
+        const data = await client.database.getAccounts([username]);
 
-        const data = response.data
         if (data.length) {
             return data[0];
         }


### PR DESCRIPTION
## Problem

The portfolio endpoints (`/private-api/portfolio` v1 and v2 in `wallet-api.ts`) fetch **dynamic global properties** and **account data** through `hive-explorer.ts`, which made REST `GET`s to an external gateway. Both calls run inside a `Promise.all`, so when that gateway is unavailable the entire portfolio request **rejects and returns HTTP 500** — there is no degraded fallback, so wallet/portfolio breaks for every user.

This was observed live: portfolio v2 was logging a steady stream of `failed to compile portfolio v2 Error: Failed to get globalProps` while the upstream returned 502.

## Fix

Fetch both pieces of chain data **directly from Hive RPC** via the `@hiveio/dhive` `Client` (already a dependency, same pattern as `private-api.ts`):

- `fetchGlobalProps()` → `client.database.getDynamicGlobalProperties()`
- `getAccount()` → `client.database.getAccounts([username])`

dhive fails over across a node list (2s timeout, `failoverThreshold: 2`) and is configured to try **our own `hapi.ecency.com` node first**, so a single slow/unavailable node no longer takes down the portfolio endpoint. Removes the now-unused `baseApiRequest`/`parseAsset` imports.

The existing `_getVestAmount` helper already handles both string assets (condenser) and nai objects, so the downstream math is unchanged.

## Test

- `tsc --noEmit` (TS 3.9.3, project tsconfig): 0 source errors.
- Verified `hapi.ecency.com` returns 200 with the expected fields for both `condenser_api.get_dynamic_global_properties` and `condenser_api.get_accounts` (~90ms).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data fetching reliability with direct blockchain access and automatic failover capabilities.
  * Improved system resilience with configured timeout and multi-node failover settings for better uptime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecency/vision-api/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->