### PR TITLE
Add /search-api/similar route for related-posts (MLT)

### DIFF
--- a/src/server/handlers/search-api.ts
+++ b/src/server/handlers/search-api.ts
@@ -66,3 +66,20 @@ export const searchPath = async (req: express.Request, res: express.Response) =>
 
     pipe(baseApiRequest(url, "POST", headers, {q}, {}, 15000), res);
 }
+
+export const searchSimilar = async (req: express.Request, res: express.Response) => {
+    const {author, permlink, title, body, tags, since, include_nsfw} = req.body;
+
+    const url = `${config.searchApiAddr}/similar`;
+    const headers = {'Authorization': config.searchApiToken};
+
+    const payload: { author: string, permlink: string, title?: string, body?: string, tags?: string[], since?: string, include_nsfw?: number } = {author, permlink};
+
+    if (title) payload.title = title;
+    if (body) payload.body = body;
+    if (tags) payload.tags = tags;
+    if (since) payload.since = since;
+    if (include_nsfw) payload.include_nsfw = include_nsfw;
+
+    pipe(baseApiRequest(url, "POST", headers, payload, {}, 15000), res);
+}

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -25,6 +25,7 @@ server
     .post("^/search-api/search-account$", searchApi.searchAccount)
     .post("^/search-api/search-tag$", searchApi.searchTag)
     .post("^/search-api/search-path$", searchApi.searchPath)
+    .post("^/search-api/similar$", searchApi.searchSimilar)
 
     // Auth Api
     .post("^/auth-api/hs-token-refresh$", authApi.hsTokenRefresh)


### PR DESCRIPTION
## Summary
Adds a `POST /search-api/similar` route that proxies to the search backend's new `/similar` endpoint, forwarding `author`/`permlink`/`title`/`body`/`tags`/`since` and injecting the search api key.

This is the proxy half of moving "Read next" / similar-entries onto Elasticsearch `more_like_this` recommendations (the backend endpoint is added in ecency/esearch-api). vapi only proxies enumerated routes, so a new route is required.

## Test plan
- [x] Typechecks (tsc).
- [ ] After merge, CI publishes `ecency/api:latest`; roll the `vision_vapi` service on the origins, then verify `POST ecency.com/search-api/similar` returns results.