### PR TITLE
Add proposal 379 vote announcement

### DIFF
--- a/src/server/handlers/announcements.ts
+++ b/src/server/handlers/announcements.ts
@@ -10,6 +10,16 @@
 */
 
 export const announcements = [
+    {
+        "id": 110,
+        "title": "Support Ecency! ❤️",
+        "description": "New proposal to support Ecency and its future development. Every vote and support counts!",
+        "button_text": "Support now",
+        "button_link": "/proposals/379",
+        "path": "/@.+/(blog|posts|wallet|points|engine|permissions|spk)",
+        "auth": true,
+        "ops": "hive://sign/op/WyJ1cGRhdGVfcHJvcG9zYWxfdm90ZXMiLHsidm90ZXIiOiAiX19zaWduZXIiLCJwcm9wb3NhbF9pZHMiOiBbMzc5XSwiYXBwcm92ZSI6dHJ1ZSwiZXh0ZW5zaW9ucyI6IFtdfV0."
+    }
     /*{
       "id": 101,
       "title": "Happy Ho ho ho holidays! 🎉",


### PR DESCRIPTION
Adds a live announcement (id 110) prompting users to vote for Ecency proposal #379.

- Shown to logged-in users on profile/wallet pages (matching the existing proposal-announcement pattern)
- `button_link` → `/proposals/379`
- `ops` encodes a valid `update_proposal_votes` operation with `proposal_ids: [379]` (array form) for mobile one-tap signing

The announcements array was previously empty (all historical entries commented out); this adds the single active entry and keeps the prior entries as commented reference.