### PR TITLE
Add proposal_ids to proposal-379 announcement for inline web voting

### DIFF
--- a/src/server/handlers/announcements.ts
+++ b/src/server/handlers/announcements.ts
@@ -7,6 +7,8 @@
   path - which path it should show, supports regex on location
   auth - should there be authorized/logged in user to show announcement,
   ops - hive uri format operation for mobile app signing
+  proposal_ids - hive proposal ids for an inline support prompt; web builds the
+                 update_proposal_votes operation from these, mobile uses ops
 */
 
 export const announcements = [
@@ -18,6 +20,7 @@ export const announcements = [
         "button_link": "/proposals/379",
         "path": "/@.+/(blog|posts|wallet|points|engine|permissions|spk)",
         "auth": true,
+        "proposal_ids": [379],
         "ops": "hive://sign/op/WyJ1cGRhdGVfcHJvcG9zYWxfdm90ZXMiLHsidm90ZXIiOiAiX19zaWduZXIiLCJwcm9wb3NhbF9pZHMiOiBbMzc5XSwiYXBwcm92ZSI6dHJ1ZSwiZXh0ZW5zaW9ucyI6IFtdfV0."
     }
     /*{


### PR DESCRIPTION
Adds `proposal_ids: [379]` to the proposal-379 announcement (id 110) so the web client can render an inline support button that casts `update_proposal_votes` directly (operation built client-side), instead of only linking to the proposal page.

Mobile continues to use the existing `ops` signing URI. Companion web change in ecency/vision-next (announcement banner inline vote).