### PR TITLE
fix(signup): resolve account-create client IP from X-Real-IP

### DIFF
--- a/src/server/handlers/private-api.test.ts
+++ b/src/server/handlers/private-api.test.ts
@@ -1,0 +1,30 @@
+import { signupClientIp } from "./private-api";
+
+// Minimal express.Request stand-in: signupClientIp only reads `headers`.
+const reqWith = (headers: Record<string, string | string[]>): any => ({ headers });
+
+describe("signupClientIp", () => {
+    it("uses the proxy-set X-Real-IP", () => {
+        expect(signupClientIp(reqWith({ "x-real-ip": "203.0.113.9" }))).toBe("203.0.113.9");
+    });
+
+    it("prefers X-Real-IP over X-Forwarded-For", () => {
+        expect(
+            signupClientIp(reqWith({ "x-forwarded-for": "198.51.100.4", "x-real-ip": "203.0.113.9" }))
+        ).toBe("203.0.113.9");
+    });
+
+    it("does not fall back to X-Forwarded-For", () => {
+        expect(signupClientIp(reqWith({ "x-forwarded-for": "198.51.100.4" }))).toBe("");
+    });
+
+    it("returns '' when X-Real-IP is absent", () => {
+        expect(signupClientIp(reqWith({}))).toBe("");
+    });
+
+    it("takes the first value when X-Real-IP is an array", () => {
+        expect(signupClientIp(reqWith({ "x-real-ip": ["198.51.100.7", "10.0.0.1"] }))).toBe(
+            "198.51.100.7"
+        );
+    });
+});

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2240,10 +2240,21 @@ export const quests = async (req: express.Request, res: express.Response) => {
     pipe(apiRequest(`users/${username}/quests`, "GET"), res);
 };
 
+/**
+ * Resolve the originating client IP for the account-create endpoints from the
+ * proxy-set X-Real-IP header. X-Forwarded-For is not used here because it can
+ * carry client-supplied values; there is no X-Forwarded-For fallback. Returns ''
+ * when the header is absent.
+ */
+export const signupClientIp = (req: express.Request): string => {
+    const realIp = req.headers['x-real-ip'];
+    return (Array.isArray(realIp) ? realIp[0] : realIp) || '';
+};
+
 export const createAccount = async (req: express.Request, res: express.Response) => {
     const { username, email, referral } = req.body;
 
-    const headers = { 'X-Real-IP-V': req.headers['x-forwarded-for'] || '' };
+    const headers = { 'X-Real-IP-V': signupClientIp(req) };
     const payload = { username, email, referral };
 
     // On-chain account creation/broadcast can take longer than the default.
@@ -2253,7 +2264,7 @@ export const createAccount = async (req: express.Request, res: express.Response)
 export const createAccountFriend = async (req: express.Request, res: express.Response) => {
     const { username, email, friend } = req.body;
 
-    const headers = { 'X-Real-IP-V': req.headers['x-forwarded-for'] || '' };
+    const headers = { 'X-Real-IP-V': signupClientIp(req) };
     const payload = { username, email, friend };
 
     // On-chain account creation/broadcast can take longer than the default.


### PR DESCRIPTION
The `account-create` / `account-create-friend` handlers derived the client IP from `X-Forwarded-For`, which can carry client-supplied values. This resolves it from the proxy-set `X-Real-IP` header instead (no `X-Forwarded-For` fallback; absent → `''`), via a small `signupClientIp()` helper.

Behavior is unchanged for normal traffic, where the headers carry the same client IP. Adds unit tests for the helper.
