### PR TITLE
Forward captcha token to account-create backend

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2252,10 +2252,12 @@ export const signupClientIp = (req: express.Request): string => {
 };
 
 export const createAccount = async (req: express.Request, res: express.Response) => {
-    const { username, email, referral } = req.body;
+    const { username, email, referral, captcha_token } = req.body;
 
     const headers = { 'X-Real-IP-V': signupClientIp(req) };
-    const payload = { username, email, referral };
+    // Forward the Turnstile token for server-side verification in onboard. Inert until
+    // onboard's CAPTCHA_MODE is soft/hard, so this is safe to ship ahead of enforcement.
+    const payload = { username, email, referral, captcha_token };
 
     // On-chain account creation/broadcast can take longer than the default.
     pipe(apiRequest(`signup/account-create`, "POST", headers, payload, {}, 30000), res);


### PR DESCRIPTION
Forwards the client CAPTCHA token (`captcha_token`) from `createAccount` through to the signup backend so it can be verified server-side. The field is optional and the backend ignores it until verification is enabled, so this is safe to ship ahead of enforcement. Pairs with the trusted-client-IP change already on `main`.
