### PR TITLE
Add /private-api/spotlights feature-spotlight endpoint

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -4,6 +4,7 @@ import axios, { AxiosRequestConfig } from "axios";
 import { cryptoUtils, Signature, Client } from '@hiveio/dhive'
 
 import { announcements } from "./announcements";
+import { spotlights, Spotlight } from "./spotlights";
 import {
     apiRequest,
     getPromotedEntries,
@@ -2135,6 +2136,25 @@ export const leaderboard = async (req: express.Request, res: express.Response) =
 
 export const getAnnouncement = async (req: express.Request, res: express.Response) => {
     res.send(announcements)
+}
+
+export const getSpotlight = async (req: express.Request, res: express.Response) => {
+    const now = Date.now();
+    // Bare ISO dates ("YYYY-MM-DD") parse as UTC midnight. `start` is inclusive from the
+    // beginning of its day; `end` is inclusive through the END of its day, so an item with
+    // end "2026-06-30" still shows throughout June 30 (UTC). A malformed date fails open
+    // (the item stays visible) rather than silently hiding a live spotlight.
+    const dayMs = 86_400_000;
+    const isBareDate = (d: string) => /^\d{4}-\d{2}-\d{2}$/.test(d);
+    const active = spotlights.filter((s: Spotlight) => {
+        const startMs = s.start ? new Date(s.start).getTime() : NaN;
+        const endMs = s.end ? new Date(s.end).getTime() : NaN;
+        const endBoundary = s.end && isBareDate(s.end) ? endMs + dayMs - 1 : endMs;
+        const startsOk = !s.start || Number.isNaN(startMs) || startMs <= now;
+        const endsOk = !s.end || Number.isNaN(endMs) || endBoundary >= now;
+        return startsOk && endsOk;
+    });
+    res.send(active);
 }
 
 export const referrals = async (req: express.Request, res: express.Response) => {

--- a/src/server/handlers/spotlights.ts
+++ b/src/server/handlers/spotlights.ts
@@ -15,6 +15,7 @@
   button_link - internal route ("/waves") or external url the button opens
   path        - which path(s) it should show on, supports regex on location; omit = everywhere
   auth        - require logged-in user (default true); set false to also show to anon
+  platforms   - which platform(s) may show it: "web" (website) and/or "mobile" (mobile app). omit = both
   start       - ISO date (UTC); do not show before this. Bare "YYYY-MM-DD" = that day at 00:00Z
   end         - ISO date (UTC); inclusive — bare "YYYY-MM-DD" shows through the END of that day
   weight      - higher wins when multiple are active
@@ -31,6 +32,7 @@ export interface Spotlight {
     button_link: string;
     path?: string | string[];
     auth?: boolean;
+    platforms?: ("web" | "mobile")[];
     start?: string;
     end?: string;
     weight?: number;

--- a/src/server/handlers/spotlights.ts
+++ b/src/server/handlers/spotlights.ts
@@ -1,0 +1,54 @@
+/*
+  Feature Spotlight content — single source of truth for the "did you know?" cards.
+  Edit this array (set start/end or bump weight) to rotate the spotlight; vision-api's
+  own CI deploys it. Mirrors announcements.ts. The server filters by the start/end
+  window only; auth/path/dismiss are applied client-side (web + mobile).
+  Keep this Spotlight interface in sync with @ecency/sdk (types/spotlight.ts) — clients
+  parse exactly this wire shape.
+
+  id          - stable slug, e.g. "waves-2026-w23"; used as the dismiss key, never reuse
+  feature     - which feature this promotes (waves|polls|points|communities|...), for gating
+  title       - card title
+  description - card body
+  icon        - optional icon name or i.ecency.com image url
+  button_text - actionable button text
+  button_link - internal route ("/waves") or external url the button opens
+  path        - which path(s) it should show on, supports regex on location; omit = everywhere
+  auth        - require logged-in user (default true); set false to also show to anon
+  start       - ISO date (UTC); do not show before this. Bare "YYYY-MM-DD" = that day at 00:00Z
+  end         - ISO date (UTC); inclusive — bare "YYYY-MM-DD" shows through the END of that day
+  weight      - higher wins when multiple are active
+  locales     - optional per-language overrides for title/description/button_text
+*/
+
+export interface Spotlight {
+    id: string;
+    feature: string;
+    title: string;
+    description: string;
+    icon?: string;
+    button_text: string;
+    button_link: string;
+    path?: string | string[];
+    auth?: boolean;
+    start?: string;
+    end?: string;
+    weight?: number;
+    locales?: { [lang: string]: Pick<Spotlight, "title" | "description" | "button_text"> };
+}
+
+export const spotlights: Spotlight[] = [
+    {
+        id: "waves-2026-w23",
+        feature: "waves",
+        title: "Have you tried Waves?",
+        description: "Share short posts and join the conversation on Hive in seconds.",
+        icon: "wave",
+        button_text: "Open Waves",
+        button_link: "/waves",
+        auth: true,
+        start: "2026-06-01",
+        end: "2026-06-30",
+        weight: 10
+    }
+];

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -56,6 +56,7 @@ server
     .get("^/private-api/referrals/:username$", privateApi.referrals)
     .get("^/private-api/referrals/:username/stats$", privateApi.referralsStats)
     .get("^/private-api/announcements$", privateApi.getAnnouncement)
+    .get("^/private-api/spotlights$", privateApi.getSpotlight)
     .get("^/private-api/chats-pub/:username$", privateApi.chatsPub)
     .get("^/private-api/channel/:username$", privateApi.channelGet)
     .get("^/private-api/proposal/active$", privateApi.proposalActive)


### PR DESCRIPTION
Adds a `/private-api/spotlights` endpoint that serves the feature-spotlight cards (educational "did you know?" prompts for under-used features), mirroring the announcements pattern.

- New `spotlights.ts` holds a typed content array — the single source of truth. Rotate the spotlight by editing this array.
- `getSpotlight` filters to active items by an inclusive start/end date window (UTC; a bare `YYYY-MM-DD` end shows through the end of that day, a malformed date fails open). `auth`/`path`/dismiss are applied client-side, as with announcements.
- The shared `Spotlight` type/query live in `@ecency/sdk` (separate PR); web + mobile consume them.

Part of the Feature Spotlight effort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a spotlight system enabling time-based content scheduling. Spotlights can be configured with start and end dates for automatic visibility control, with enhanced handling to keep content visible through the end of its scheduled date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->