### PR TITLE
Give vision-api its own deploy (roll out vision_vapi)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,3 +50,50 @@ jobs:
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
+  # Roll the freshly-pushed image out to the running `vision_vapi` swarm service in each
+  # region, so a vision-api change (e.g. rotating Feature Spotlight content) ships on its
+  # own instead of waiting for the next vision-next deploy. Mirrors the converge-wait that
+  # vision-next uses for `vision_web`. Assumes the swarm service is named `vision_vapi`
+  # (stack `vision`, service `vapi`) — verify once with `docker service ls`.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        region: [EU, US, SG]
+    steps:
+      - name: Deploy vision_vapi (${{ matrix.region }})
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets[format('SSH_HOST_{0}', matrix.region)] }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            api_pull="$(docker pull ecency/api:latest)"; printf '%s\n' "$api_pull"
+            if printf '%s' "$api_pull" | grep -q 'Image is up to date'; then
+              echo "vision_vapi image unchanged; no rollout expected"
+            else
+              docker service update --image ecency/api:latest --with-registry-auth vision_vapi
+              # service update returns before Swarm populates UpdateStatus, so wait for
+              # `completed`; fail fast on rollback/pause; fail on timeout in any other state.
+              state=""
+              for i in $(seq 1 60); do
+                state="$(docker service inspect vision_vapi --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
+                case "$state" in
+                  completed) break ;;
+                  rollback_*|paused)
+                    echo "::error::vision_vapi rolled back (UpdateStatus=$state); prod still on the previous image"
+                    exit 1 ;;
+                esac
+                sleep 5
+              done
+              if [ "$state" != "completed" ]; then
+                echo "::error::vision_vapi did not converge within ~5m (UpdateStatus=${state:-empty})"
+                exit 1
+              fi
+              echo "vision_vapi converged (UpdateStatus=completed)"
+            fi
+            docker system prune -f
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,13 @@ on:
   push:
     branches:
       - main
+
+# Serialize runs on a ref and cancel superseded ones, so an older run can't roll prod
+# back to its (older) image after a newer run has already deployed.
+concurrency:
+  group: vapi-cicd-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deps:
     runs-on: ubuntu-24.04
@@ -23,6 +30,8 @@ jobs:
   build:
     needs: deps
     runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.docker_build.outputs.digest }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
@@ -65,35 +74,40 @@ jobs:
     steps:
       - name: Deploy vision_vapi (${{ matrix.region }})
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
         with:
           host: ${{ secrets[format('SSH_HOST_{0}', matrix.region)] }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
+          envs: IMAGE_DIGEST
           script: |
-            api_pull="$(docker pull ecency/api:latest)"; printf '%s\n' "$api_pull"
-            if printf '%s' "$api_pull" | grep -q 'Image is up to date'; then
-              echo "vision_vapi image unchanged; no rollout expected"
-            else
-              docker service update --image ecency/api:latest --with-registry-auth vision_vapi
-              # service update returns before Swarm populates UpdateStatus, so wait for
-              # `completed`; fail fast on rollback/pause; fail on timeout in any other state.
-              state=""
-              for i in $(seq 1 60); do
-                state="$(docker service inspect vision_vapi --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
-                case "$state" in
-                  completed) break ;;
-                  rollback_*|paused)
-                    echo "::error::vision_vapi rolled back (UpdateStatus=$state); prod still on the previous image"
-                    exit 1 ;;
-                esac
-                sleep 5
-              done
-              if [ "$state" != "completed" ]; then
-                echo "::error::vision_vapi did not converge within ~5m (UpdateStatus=${state:-empty})"
-                exit 1
-              fi
-              echo "vision_vapi converged (UpdateStatus=completed)"
+            # Deploy the exact image digest THIS run built — never the mutable :latest tag —
+            # so out-of-order :latest writes from overlapping runs cannot move prod.
+            if [ -z "$IMAGE_DIGEST" ]; then
+              echo "::error::missing build digest; refusing to deploy a mutable tag"
+              exit 1
             fi
+            IMAGE="ecency/api@${IMAGE_DIGEST}"
+            if ! docker pull "$IMAGE"; then
+              echo "::error::failed to pull $IMAGE"
+              exit 1
+            fi
+            # --detach=false blocks until the rollout reaches a terminal state, so the
+            # UpdateStatus read afterwards is THIS rollout's, not a stale prior 'completed'.
+            docker service update --image "$IMAGE" --with-registry-auth --detach=false vision_vapi
+            upd_rc=$?
+            state="$(docker service inspect vision_vapi --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' 2>/dev/null || echo "")"
+            case "$state" in
+              rollback_*|paused)
+                echo "::error::vision_vapi rolled back (UpdateStatus=$state); prod still on the previous image"
+                exit 1 ;;
+            esac
+            if [ "$upd_rc" -ne 0 ] && [ "$state" != "completed" ]; then
+              echo "::error::vision_vapi update failed (rc=$upd_rc, UpdateStatus=${state:-none})"
+              exit 1
+            fi
+            echo "vision_vapi on $IMAGE (UpdateStatus=${state:-none})"
             docker system prune -f
 


### PR DESCRIPTION
Gives vision-api its own rollout so a vision-api merge (e.g. rotating Feature Spotlight content) ships on its own, instead of waiting for the next vision-next deploy.

**What it adds:** a `deploy` job (matrix EU/US/SG, after `build`) that SSHes to each prod box and rolls the running `vision_vapi` swarm service to the freshly-pushed `ecency/api:latest`, with the same converge-wait vision-next uses for `vision_web` (waits for UpdateStatus=completed; fails on rollback/pause/timeout; skips when the image is unchanged).

**Why no vision-next change is needed:** vision-next deploys via `docker stack deploy` from a compose that still includes the `vapi` service, so it reconciles `vision_vapi` to `ecency/api:latest` on every deploy regardless of the `docker pull` line — removing that line would not stop it. With this job, both pipelines simply converge `vision_vapi` to the same `:latest` (idempotent). Fully removing vapi from vision-next is a larger, separate change and is not required for the goal.

**Merge prerequisites (do not merge until done):**
1. Add these secrets to the vision-api repo (same values as vision-next): `SSH_HOST_EU`, `SSH_HOST_US`, `SSH_HOST_SG`, `SSH_USERNAME`, `SSH_KEY`, `SSH_PORT`. (`DOCKERHUB_*` already present.)
2. Verify the swarm service is named `vision_vapi` on a box (`docker service ls`).

Opened as **draft**. Suggested first run: merge, push a trivial vision-api change, confirm the deploy job converges and the API responds, before relying on it.