### PR TITLE
feat: add rc-delegation-price and rc-delegation-active private-api routes

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2757,6 +2757,25 @@ export const boostedPlusAccount = async (req: express.Request, res: express.Resp
     pipe(apiRequest(`boosted-plus-accounts/${account}`, "GET"), res);
 }
 
+export const rcDelegationPrice = async (req: express.Request, res: express.Response) => {
+    const username = await validateCode(req);
+    if (!username) {
+        res.status(401).send("Unauthorized");
+        return;
+    }
+    pipe(apiRequest(`rc-delegation-price`, "GET"), res);
+}
+
+export const rcDelegationActive = async (req: express.Request, res: express.Response) => {
+    const username = await validateCode(req);
+    if (!username) {
+        res.status(401).send("Unauthorized");
+        return;
+    }
+    // Self-only: always check the authenticated user's own active top-up.
+    pipe(apiRequest(`rc-delegation-active/${username}`, "GET"), res);
+}
+
 export const boostOptions = async (req: express.Request, res: express.Response) => {
     const username = await validateCode(req);
     if (!username) {

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -135,6 +135,8 @@ server
     .post("^/private-api/promoted-post$", privateApi.promotedPost)
     .post("^/private-api/boost-plus-price$", privateApi.boostPlusPrice)
     .post("^/private-api/boosted-plus-account$", privateApi.boostedPlusAccount)
+    .post("^/private-api/rc-delegation-price$", privateApi.rcDelegationPrice)
+    .post("^/private-api/rc-delegation-active$", privateApi.rcDelegationActive)
     .post("^/private-api/boost-options$", privateApi.boostOptions)
     .post("^/private-api/boosted-post$", privateApi.boostedPost)
     .post("^/private-api/ai-generate-price$", privateApi.aiGeneratePrice)


### PR DESCRIPTION
Exposes the RC top-up endpoints to the web SDK, mirroring the existing boost-plus handlers.

- `POST /private-api/rc-delegation-price` -> `rcDelegationPrice` -> `apiRequest('rc-delegation-price', 'GET')` (the Points-cost-per-duration ladder).
- `POST /private-api/rc-delegation-active` -> `rcDelegationActive` -> `apiRequest('rc-delegation-active/<username>', 'GET')`, using the code-authenticated username so the active-top-up check is always self-only.

Both require a valid `code` (401 otherwise), same as `promotePrice` / `boostPlusPrice` / `boostedPlusAccount`. The backend endpoints land in the merged ePoints + esync changes; the upstream gateway must also pass these paths through. Without this, vision-next gets 404s on the RC top-up flow.