### PR TITLE
feat(stripe): anonymous paid-account create-intent + unify Turnstile verification in vapi

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,5 +10,16 @@ export default {
     // top of network position). Must match STRIPE_INTERNAL_SECRET in the ePoints env.
     // NO default: when unset, the Stripe routes fail closed (503) rather than forward an
     // empty secret -- and without coupling the rest of vapi to this one secret.
-    stripeInternalSecret: process.env.STRIPE_INTERNAL_SECRET
+    stripeInternalSecret: process.env.STRIPE_INTERNAL_SECRET,
+    // Cloudflare Turnstile (server-side captcha) secret. The single verifier for the
+    // account-create and paid-account-create routes; server-side only, never sent to clients.
+    turnstileSecret: process.env.TURNSTILE_SECRET,
+    // account-create captcha enforcement: "off" (default; no check, ships dark), "soft"
+    // (verify + log only, never block), "hard" (require a valid token). The paid-account
+    // route always verifies regardless of this.
+    captchaMode: (process.env.CAPTCHA_MODE || "off").trim().toLowerCase(),
+    // Comma-separated referral values exempt from the account-create captcha gate (from env;
+    // empty by default).
+    captchaBypassReferrals: (process.env.CAPTCHA_BYPASS_REFERRALS || "")
+        .split(",").map((s: string) => s.trim()).filter(Boolean)
 };

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2272,12 +2272,66 @@ export const signupClientIp = (req: express.Request): string => {
     return (Array.isArray(realIp) ? realIp[0] : realIp) || '';
 };
 
+/**
+ * Server-side Cloudflare Turnstile verification -- the single captcha verifier for the
+ * account-create and paid-account-create routes. Returns true ONLY on a confirmed-human
+ * token; fails CLOSED on a missing secret/token, provider error, or rejection (a network
+ * blip must never open the gate). The secret is server-side only (config.turnstileSecret).
+ */
+const verifyTurnstile = async (token: unknown, ip: string): Promise<boolean> => {
+    const secret = config.turnstileSecret;
+    if (!secret || typeof token !== "string" || !token.trim()) {
+        return false;
+    }
+    try {
+        const form = new URLSearchParams();
+        form.append("secret", secret);
+        form.append("response", token.trim());
+        if (ip) form.append("remoteip", ip);
+        const r = await axios.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+            form, { timeout: 8000, headers: { "Content-Type": "application/x-www-form-urlencoded" } });
+        return r?.data?.success === true;
+    } catch (err) {
+        console.warn("verifyTurnstile: siteverify error", (err as Error)?.message);
+        return false;
+    }
+};
+
+/**
+ * Apply the account-create captcha gate per config.captchaMode. Returns true when the request
+ * must be REJECTED (only possible in "hard"). "soft" verifies for telemetry but never blocks;
+ * "off" (default) is a no-op so this ships dark. Referrals in captchaBypassReferrals are exempt.
+ */
+const accountCaptchaRejected = async (token: unknown, ip: string, referral: unknown): Promise<boolean> => {
+    const mode = config.captchaMode;
+    if (mode !== "hard" && mode !== "soft") {
+        return false;
+    }
+    if (typeof referral === "string" && config.captchaBypassReferrals.includes(referral)) {
+        return false;
+    }
+    const ok = await verifyTurnstile(token, ip);
+    if (mode === "soft") {
+        const hasToken = typeof token === "string" && token.trim().length > 0;
+        console.log(`captcha soft: ${ok ? "ok" : hasToken ? "reject" : "notoken"}`);
+        return false;
+    }
+    return !ok;
+};
+
 export const createAccount = async (req: express.Request, res: express.Response) => {
     const { username, email, referral, captcha_token } = req.body;
+    const ip = signupClientIp(req);
 
-    const headers = { 'X-Real-IP-V': signupClientIp(req) };
-    // Forward the Turnstile token for server-side verification in onboard. Inert until
-    // onboard's CAPTCHA_MODE is soft/hard, so this is safe to ship ahead of enforcement.
+    // Single server-side captcha gate (config.captchaMode). Ships dark (off) by default; the
+    // token is still forwarded so the transition needs no client change.
+    if (await accountCaptchaRejected(captcha_token, ip, referral)) {
+        res.status(406).json({ code: 113, message: "Please complete the verification and try again." });
+        return;
+    }
+
+    const headers = { 'X-Real-IP-V': ip };
     const payload = { username, email, referral, captcha_token };
 
     // On-chain account creation/broadcast can take longer than the default.
@@ -2819,6 +2873,65 @@ export const stripeOrderStatus = async (req: express.Request, res: express.Respo
     // Owner-scoped: ePoints filters by ?user, so a caller can only read its own order.
     const headers = { "X-Internal-Secret": secret };
     pipe(apiRequest(`stripe/order/${encodeURIComponent(payment_intent.trim())}?user=${encodeURIComponent(username)}`, "GET", headers, {}, {}, 20000), res);
+}
+
+export const stripeCreateAccountIntent = async (req: express.Request, res: express.Response) => {
+    // ANONYMOUS paid-account purchase: NO validateCode (the buyer has no Hive account yet).
+    // The captcha is the human gate (ALWAYS enforced for this paid flow, independent of
+    // CAPTCHA_MODE). The backend re-validates the username/email/availability and computes
+    // the amount server-side before charging; this hop only authenticates with the shared
+    // secret and forwards the request.
+    const secret = config.stripeInternalSecret;
+    if (!secret) {
+        res.status(503).send("payments not configured");
+        return;
+    }
+    const ip = signupClientIp(req);
+    const { sku, nonce, meta, captcha_token } = req.body as {
+        sku?: string; nonce?: string;
+        meta?: { username?: string; email?: string; referral?: string };
+        captcha_token?: string;
+    };
+    // This route mints ONLY the accounts rail; never let it create a points order (which the
+    // points route binds to an authenticated caller).
+    if (typeof sku !== "string" || !sku.endsWith("accounts")) {
+        res.status(400).send("invalid product");
+        return;
+    }
+    if (!(await verifyTurnstile(captcha_token, ip))) {
+        res.status(406).json({ code: 113, message: "Please complete the verification and try again." });
+        return;
+    }
+    const username = typeof meta?.username === "string" ? meta.username.trim().toLowerCase() : "";
+    if (!username) {
+        res.status(400).send("username required");
+        return;
+    }
+    // `user` carries the new account name as the order identity; the backend re-derives +
+    // re-validates it. Forward the client IP for backend-side rate-limiting / audit.
+    const headers = { "X-Internal-Secret": secret, "X-Real-IP-V": ip };
+    const payload = { user: username, sku, nonce, meta };
+    pipe(apiRequest(`stripe/create-intent`, "POST", headers, payload, {}, 20000), res);
+}
+
+export const stripeAccountStatus = async (req: express.Request, res: express.Response) => {
+    // ANONYMOUS status poll: no Hive account yet, so no validateCode owner-binding. Scope by
+    // the buyer-supplied username + payment_intent; the backend filters by ?user, so the order
+    // resolves only when BOTH match what it created. Status is low-sensitivity.
+    const secret = config.stripeInternalSecret;
+    if (!secret) {
+        res.status(503).send("payments not configured");
+        return;
+    }
+    const { payment_intent, username } = req.body as { payment_intent?: string; username?: string };
+    const pi = typeof payment_intent === "string" ? payment_intent.trim() : "";
+    const user = typeof username === "string" ? username.trim().toLowerCase() : "";
+    if (!pi || !user) {
+        res.status(400).send("payment_intent and username required");
+        return;
+    }
+    const headers = { "X-Internal-Secret": secret };
+    pipe(apiRequest(`stripe/order/${encodeURIComponent(pi)}?user=${encodeURIComponent(user)}`, "GET", headers, {}, {}, 20000), res);
 }
 
 export const boostOptions = async (req: express.Request, res: express.Response) => {

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2332,7 +2332,14 @@ export const createAccount = async (req: express.Request, res: express.Response)
     }
 
     const headers = { 'X-Real-IP-V': ip };
-    const payload = { username, email, referral, captcha_token };
+    // A Turnstile token is SINGLE-USE. When vapi is the verifier (mode != off) it was already
+    // consumed above, so it must NOT be forwarded for a second verification downstream (that
+    // would read as a duplicate and reject). Downstream captcha MUST be disabled when vapi
+    // enforces -- see the rollout. When off, forward as before so nothing changes.
+    const payload = {
+        username, email, referral,
+        captcha_token: config.captchaMode === "off" ? captcha_token : undefined,
+    };
 
     // On-chain account creation/broadcast can take longer than the default.
     pipe(apiRequest(`signup/account-create`, "POST", headers, payload, {}, 30000), res);
@@ -2898,19 +2905,22 @@ export const stripeCreateAccountIntent = async (req: express.Request, res: expre
         res.status(400).send("invalid product");
         return;
     }
-    if (!(await verifyTurnstile(captcha_token, ip))) {
-        res.status(406).json({ code: 113, message: "Please complete the verification and try again." });
-        return;
-    }
+    // Validate cheap inputs BEFORE the single-use Turnstile check, so a fixable input error
+    // (e.g. a missing username) never burns the user's one-time captcha token.
     const username = typeof meta?.username === "string" ? meta.username.trim().toLowerCase() : "";
     if (!username) {
         res.status(400).send("username required");
         return;
     }
+    if (!(await verifyTurnstile(captcha_token, ip))) {
+        res.status(406).json({ code: 113, message: "Please complete the verification and try again." });
+        return;
+    }
     // `user` carries the new account name as the order identity; the backend re-derives +
-    // re-validates it. Forward the client IP for backend-side rate-limiting / audit.
+    // re-validates it. Forward a NORMALIZED meta.username so meta and `user` agree. Forward the
+    // client IP for backend-side rate-limiting / audit.
     const headers = { "X-Internal-Secret": secret, "X-Real-IP-V": ip };
-    const payload = { user: username, sku, nonce, meta };
+    const payload = { user: username, sku, nonce, meta: meta ? { ...meta, username } : meta };
     pipe(apiRequest(`stripe/create-intent`, "POST", headers, payload, {}, 20000), res);
 }
 

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -139,6 +139,8 @@ server
     .post("^/private-api/rc-delegation-active$", privateApi.rcDelegationActive)
     .post("^/private-api/stripe-create-intent$", privateApi.stripeCreateIntent)
     .post("^/private-api/stripe-order-status$", privateApi.stripeOrderStatus)
+    .post("^/private-api/stripe-account-intent$", privateApi.stripeCreateAccountIntent)
+    .post("^/private-api/stripe-account-status$", privateApi.stripeAccountStatus)
     .post("^/private-api/boost-options$", privateApi.boostOptions)
     .post("^/private-api/boosted-post$", privateApi.boostedPost)
     .post("^/private-api/ai-generate-price$", privateApi.aiGeneratePrice)


### PR DESCRIPTION
Makes vapi the **single server-side Cloudflare Turnstile verifier**, and adds the **anonymous paid-account** create-intent + status pass-throughs for the web card flow.

## Turnstile (one verifier)
- `verifyTurnstile(token, ip)` — `siteverify` with the env secret, **fail-closed** (returns true only on `success === true`; a missing secret/token, provider error, timeout, or rejection all return false).
- `accountCaptchaRejected` applies `CAPTCHA_MODE`: **off** (default — no check, ships dark), **soft** (verify + log, never block), **hard** (require a valid token → 406). `createAccount` now runs this gate, then forwards exactly as before. Referrals in `CAPTCHA_BYPASS_REFERRALS` (env, empty default) are exempt.

**Ships dark:** with `CAPTCHA_MODE=off` the gate is a no-op (short-circuits before any network call), so `createAccount` is behaviorally unchanged — operators enable it (`soft`→`hard`) when ready. `TURNSTILE_SECRET` must be set in the env **before** flipping to `hard` (the verifier fails closed).

## Anonymous paid-account routes (P6c)
- `stripe-account-intent`: no `validateCode` (the buyer has no account yet) — gated by Turnstile (always), `sku.endsWith("accounts")` only, 503 without the shared secret. Forwards `{user: username, sku, nonce, meta}` + `X-Internal-Secret` + client IP; the backend re-validates the username (consensus syntax + on-chain availability) and computes the amount server-side before charging.
- `stripe-account-status`: anonymous poll scoped by `payment_intent` + `username` (the PI is the capability secret); status is low-sensitivity.

Uses the existing backend `stripe/create-intent` + `stripe/order/<pi>` endpoints — no api-proxy change.

## Review
Adversarial review = **GO**, no must-fixes, confirmed **leak-clean** and fail-closed. Backend-side hardening (per-IP rate-limit on the forwarded IP; status response stays PII-free) tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable CAPTCHA protection for account creation using Cloudflare Turnstile
  * Support for optional CAPTCHA bypass based on referral sources
  * Introduced new payment flow for anonymous account purchases via Stripe
  * Enhanced IP address tracking for security verification

* **Configuration**
  * New environment variable support for CAPTCHA secrets and modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->