### PR TITLE
chore(captcha): enforce Turnstile on every account-create request by default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,12 +14,8 @@ export default {
     // Cloudflare Turnstile (server-side captcha) secret. The single verifier for the
     // account-create and paid-account-create routes; server-side only, never sent to clients.
     turnstileSecret: process.env.TURNSTILE_SECRET,
-    // account-create captcha enforcement: "off" (default; no check, ships dark), "soft"
-    // (verify + log only, never block), "hard" (require a valid token). The paid-account
-    // route always verifies regardless of this.
-    captchaMode: (process.env.CAPTCHA_MODE || "off").trim().toLowerCase(),
-    // Comma-separated referral values exempt from the account-create captcha gate (from env;
-    // empty by default).
-    captchaBypassReferrals: (process.env.CAPTCHA_BYPASS_REFERRALS || "")
-        .split(",").map((s: string) => s.trim()).filter(Boolean)
+    // account-create captcha enforcement. "hard" (default) requires a valid token for every
+    // request; "off" is an operator-only break-glass (e.g. a Turnstile provider outage), since
+    // verification otherwise fails closed. The paid-account route always verifies regardless.
+    captchaMode: (process.env.CAPTCHA_MODE || "hard").trim().toLowerCase()
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import config from './config';
 
 let app = require('./server').default;
 
@@ -24,6 +25,11 @@ const server = express()
             return;
         }
         console.log(`> Started on port ${port}`);
+        // Surface the effective account-create captcha enforcement, so a stray CAPTCHA_MODE
+        // (anything but "off" is now "hard") shows up in startup logs instead of being silent.
+        console.log(
+            `> account-create captcha: ${config.captchaMode === 'off' ? 'OFF (break-glass)' : 'hard'}`
+        );
     });
 
 ['SIGINT', 'SIGTERM'].forEach((signal: any) => {

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2299,47 +2299,30 @@ const verifyTurnstile = async (token: unknown, ip: string): Promise<boolean> => 
 };
 
 /**
- * Apply the account-create captcha gate per config.captchaMode. Returns true when the request
- * must be REJECTED (only possible in "hard"). "soft" verifies for telemetry but never blocks;
- * "off" (default) is a no-op so this ships dark. Referrals in captchaBypassReferrals are exempt.
+ * Turnstile gate for account creation. Returns true when the request must be REJECTED.
+ * Enforced for every request by default (config.captchaMode "hard"); an operator can set
+ * "off" as an emergency break-glass, since verification otherwise fails closed.
  */
-const accountCaptchaRejected = async (token: unknown, ip: string, referral: unknown): Promise<boolean> => {
-    const mode = config.captchaMode;
-    if (mode !== "hard" && mode !== "soft") {
+const accountCaptchaRejected = async (token: unknown, ip: string): Promise<boolean> => {
+    if (config.captchaMode === "off") {
         return false;
     }
-    if (typeof referral === "string" && config.captchaBypassReferrals.includes(referral)) {
-        return false;
-    }
-    const ok = await verifyTurnstile(token, ip);
-    if (mode === "soft") {
-        const hasToken = typeof token === "string" && token.trim().length > 0;
-        console.log(`captcha soft: ${ok ? "ok" : hasToken ? "reject" : "notoken"}`);
-        return false;
-    }
-    return !ok;
+    return !(await verifyTurnstile(token, ip));
 };
 
 export const createAccount = async (req: express.Request, res: express.Response) => {
     const { username, email, referral, captcha_token } = req.body;
     const ip = signupClientIp(req);
 
-    // Single server-side captcha gate (config.captchaMode). Ships dark (off) by default; the
-    // token is still forwarded so the transition needs no client change.
-    if (await accountCaptchaRejected(captcha_token, ip, referral)) {
+    // Single server-side Turnstile gate, enforced by default. vapi is the sole verifier, so the
+    // (single-use) token is consumed here and never forwarded downstream.
+    if (await accountCaptchaRejected(captcha_token, ip)) {
         res.status(406).json({ code: 113, message: "Please complete the verification and try again." });
         return;
     }
 
     const headers = { 'X-Real-IP-V': ip };
-    // A Turnstile token is SINGLE-USE. When vapi is the verifier (mode != off) it was already
-    // consumed above, so it must NOT be forwarded for a second verification downstream (that
-    // would read as a duplicate and reject). Downstream captcha MUST be disabled when vapi
-    // enforces -- see the rollout. When off, forward as before so nothing changes.
-    const payload = {
-        username, email, referral,
-        captcha_token: config.captchaMode === "off" ? captcha_token : undefined,
-    };
+    const payload = { username, email, referral };
 
     // On-chain account creation/broadcast can take longer than the default.
     pipe(apiRequest(`signup/account-create`, "POST", headers, payload, {}, 30000), res);


### PR DESCRIPTION
## What
Make vapi the single Turnstile verifier for account creation, and simplify the gate to match the always-verify paid-account route:

- **`CAPTCHA_MODE` now defaults to `hard`** — every `/private-api/account-create` request requires a valid Turnstile token.
- **`off` remains only as an operator break-glass** (e.g. a Cloudflare Turnstile provider outage), since `verifyTurnstile` fails closed.
- Removed the `soft` telemetry mode and collapsed the gate so verification applies **uniformly to every request**. The single-use token is consumed here and is **not forwarded downstream** (the backend no longer checks).

Typecheck: clean for the changed files (`tsc 5.4` reports 2 errors, both pre-existing in unrelated files — `wallet-api.ts:2051`, `util.ts:21`). vision-api has no PR CI; verified locally.

## ⚠️ Ships HOT — prerequisites before merge/deploy
Unlike the previous default (`off` = no-op), this enforces the moment the new `ecency/api:latest` is deployed, **fail-closed**. So before this reaches a running environment:

1. **Set the `TURNSTILE_SECRET` repo secret** (vision-next) for that environment first — without it, `verifyTurnstile` fails closed and **all signups 406**. Staging auto-deploys on `develop` pushes, so set the staging secret before merging.
2. **Fix the mobile `/embed/turnstile` widget** before the prod (master) release — otherwise mobile signups can't produce a token and will be blocked.
3. Web prod must be shipping the Turnstile widget (lands with the next vision-next master release).

Kept as a **draft** until those are in place. After cutover, `off` is available via `docker service update --env-add CAPTCHA_MODE=off vision_vapi` purely as an emergency switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Security**
  * CAPTCHA verification for account creation is now enforced by default (previously it defaulted to an “off” behavior).
  * Referral-based CAPTCHA bypasses have been removed.
  * Account creation CAPTCHA decision-making was streamlined for consistent enforcement.
* **Operational Improvements**
  * Startup now logs the effective CAPTCHA enforcement mode for account creation (including when it is set to “off”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->