### PR TITLE
Add /private-api/waves/feed route (combined waves feed)

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2240,10 +2240,12 @@ export const wavesFeed = async (req: express.Request, res: express.Response) => 
     const { limit, cursor, tag, following, container } = req.query;
     const params = new URLSearchParams();
 
-    if (limit) params.set("limit", String(limit));
-    if (cursor) params.set("cursor", String(cursor));
-    if (tag) params.set("tag", String(tag));
-    if (following) params.set("following", String(following));
+    // These are single-value; ignore array input (duplicate params) so a
+    // String([...]) never forwards a comma-joined value to the backend.
+    if (limit && !Array.isArray(limit)) params.set("limit", String(limit));
+    if (cursor && !Array.isArray(cursor)) params.set("cursor", String(cursor));
+    if (tag && !Array.isArray(tag)) params.set("tag", String(tag));
+    if (following && !Array.isArray(following)) params.set("following", String(following));
 
     // container is optional and repeatable (omit for the full combined feed).
     if (Array.isArray(container)) {

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2236,6 +2236,26 @@ export const wavesTrendingAuthors = async (req: express.Request, res: express.Re
     pipe(apiRequest(u, "GET"), res);
 };
 
+export const wavesFeed = async (req: express.Request, res: express.Response) => {
+    const { limit, cursor, tag, following, container } = req.query;
+    const params = new URLSearchParams();
+
+    if (limit) params.set("limit", String(limit));
+    if (cursor) params.set("cursor", String(cursor));
+    if (tag) params.set("tag", String(tag));
+    if (following) params.set("following", String(following));
+
+    // container is optional and repeatable (omit for the full combined feed).
+    if (Array.isArray(container)) {
+        container.forEach((c) => params.append("container", String(c)));
+    } else if (container) {
+        params.append("container", String(container));
+    }
+
+    const u = `waves/feed?${params.toString()}`;
+    pipe(apiRequest(u, "GET"), res);
+};
+
 export const points = async (req: express.Request, res: express.Response) => {
     const { username } = req.body;
     pipe(apiRequest(`users/${username}`, "GET"), res);

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -61,6 +61,7 @@ server
     .get("^/private-api/channel/:username$", privateApi.channelGet)
     .get("^/private-api/proposal/active$", privateApi.proposalActive)
     .get("^/private-api/pub-notifications/:username", privateApi.publicUnreadNotifications)
+    .get("^/private-api/waves/feed$", privateApi.wavesFeed)
     .get("^/private-api/waves/tags$", privateApi.wavesTags)
     .get("^/private-api/waves/account$", privateApi.wavesAccount)
     .get("^/private-api/waves/following", privateApi.wavesFollowing)


### PR DESCRIPTION
Adds the `wavesFeed` handler + `GET ^/private-api/waves/feed$` route, mirroring the existing waves routes. Forwards `limit`, `cursor`, `tag`, `following` and repeatable `container` to the backend combined feed endpoint.

Required for the combined waves feed: without this route `/private-api/waves/feed` is not proxied and falls through to the app root. Pairs with ecency/esync-py (feed endpoint) and the vision-next web change.