### PR TITLE
fix(wavesFeed): unblock build (typed container forEach param)

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2250,7 +2250,7 @@ export const wavesFeed = async (req: express.Request, res: express.Response) => 
 
     // container is optional and repeatable (omit for the full combined feed).
     if (Array.isArray(container)) {
-        container.forEach((c) => params.append("container", String(c)));
+        (container as unknown[]).forEach((c) => params.append("container", String(c)));
     } else if (container) {
         params.append("container", String(container));
     }


### PR DESCRIPTION
**The vapi build has been broken since #35**, so the wavesFeed route, combined trending route, and observer/author forwarding never deployed (the service is ~38h stale on the pre-#35 image; CI runs for #35/#36/#37 all failed at `Build and push`).

Cause: `req.query.container` is `any`, so `Array.isArray(container)` narrowed it to `any[]` and the `forEach((c) => ...)` callback param was implicit-any. The Docker build's `noImplicitAny` rejects it (TS7006); local `tsc` missed it due to a different `@types/express` resolution.

Fix: cast to `unknown[]` so the param is explicitly typed. Verified the production build now `Compiled successfully`. Merging this rebuilds + auto-deploys the image, bringing all three previously-merged waves-feed routes live.