### PR TITLE
feat(waves): proxy /private-api/waves/shorts to esync shorts feed

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2259,6 +2259,28 @@ export const wavesFeed = async (req: express.Request, res: express.Response) => 
     pipe(apiRequest(u, "GET"), res);
 };
 
+export const wavesShorts = async (req: express.Request, res: express.Response) => {
+    const { limit, cursor, tag, author, observer, container } = req.query;
+    const params = new URLSearchParams();
+
+    // Single-value params; ignore array (duplicate) input as wavesFeed does.
+    if (limit && !Array.isArray(limit)) params.set("limit", String(limit));
+    if (cursor && !Array.isArray(cursor)) params.set("cursor", String(cursor));
+    if (tag && !Array.isArray(tag)) params.set("tag", String(tag));
+    if (author && !Array.isArray(author)) params.set("author", String(author));
+    if (observer && !Array.isArray(observer)) params.set("observer", String(observer));
+
+    // container is optional and repeatable (omit for the full combined shorts feed).
+    if (Array.isArray(container)) {
+        (container as unknown[]).forEach((c) => params.append("container", String(c)));
+    } else if (container) {
+        params.append("container", String(container));
+    }
+
+    const u = `waves/shorts?${params.toString()}`;
+    pipe(apiRequest(u, "GET"), res);
+};
+
 export const points = async (req: express.Request, res: express.Response) => {
     const { username } = req.body;
     pipe(apiRequest(`users/${username}`, "GET"), res);

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -62,6 +62,7 @@ server
     .get("^/private-api/proposal/active$", privateApi.proposalActive)
     .get("^/private-api/pub-notifications/:username", privateApi.publicUnreadNotifications)
     .get("^/private-api/waves/feed$", privateApi.wavesFeed)
+    .get("^/private-api/waves/shorts$", privateApi.wavesShorts)
     .get("^/private-api/waves/tags$", privateApi.wavesTags)
     .get("^/private-api/waves/account$", privateApi.wavesAccount)
     .get("^/private-api/waves/following", privateApi.wavesFollowing)


### PR DESCRIPTION
Adds the `/private-api/waves/shorts` route + `wavesShorts` handler, mirroring `wavesFeed`: forwards `limit`/`cursor`/`tag`/`author`/`observer` + repeatable `container` to the esync `waves/shorts` endpoint.

Backs the new Shorts (reels) tab. The esync backend (`GET /api/waves/shorts`) is merged + deployed (esync-py #18); without this route the path falls through to the vapi landing page. No new allowlist needed (the api-proxy `/waves` regex already covers it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new private API endpoint for retrieving “shorts” results.
  * The endpoint supports the same query options as the existing feed endpoint, including limits, pagination, tags, authors, observers, and container filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->