### PR TITLE
Replace Chainstack with public RPC provider pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
 * `HIVESIGNER_SECRET` -  hivesigner client secret
 * `SEARCH_API_ADDR` - hivesearcher api endpoint
 * `SEARCH_API_SECRET` - hivesearcher api auth token
-* `CHAINSTACK_API_KEY` - Chainstack API key used to enumerate nodes and request balances directly from each network-specific endpoint.
-* `CHAINZ_API_KEY` - Chainz API key used to perform balance lookups when the Chainz provider is requested.
-* `BLOCKSTREAM_CLIENT_ID` - OAuth client identifier used to request temporary access tokens for the Blockstream Explorer Enterprise API fallback.
-* `BLOCKSTREAM_CLIENT_SECRET` - OAuth client secret paired with the client identifier for generating Blockstream access tokens.
+* `BLOCKSTREAM_CLIENT_ID` - optional OAuth client identifier used to request temporary access tokens for the Blockstream Explorer Enterprise API (BTC fallback).
+* `BLOCKSTREAM_CLIENT_SECRET` - optional OAuth client secret paired with the client identifier for generating Blockstream access tokens.
+* `HELIUS_API_KEY` - optional Helius API key added as an extra Solana RPC fallback.
+* `ETH_RPC_URLS` / `BNB_RPC_URLS` / `SOL_RPC_URLS` / `BTC_ESPLORA_URLS` - optional comma-separated endpoint lists overriding the built-in public provider pools (see `src/server/chain-providers.ts`).
 
 ##### Start api in dev
 `$ yarn start`
@@ -54,10 +54,9 @@ Configure the instance using following environment variables:
  * `HIVESIGNER_SECRET`
  * `SEARCH_API_ADDR`
  * `SEARCH_API_SECRET`
- * `CHAINSTACK_API_KEY`
- * `CHAINZ_API_KEY`
  * `BLOCKSTREAM_CLIENT_ID`
  * `BLOCKSTREAM_CLIENT_SECRET`
+ * `HELIUS_API_KEY`
 
 ```bash
 docker run -it --rm -p 3000:3000 -e PRIVATE_API_ADDR=https://api.example.com -e PRIVATE_API_AUTH=verysecretpassword ecency/api:latest

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Configure the instance using following environment variables:
  * `BLOCKSTREAM_CLIENT_ID`
  * `BLOCKSTREAM_CLIENT_SECRET`
  * `HELIUS_API_KEY`
+ * `ETH_RPC_URLS`
+ * `BNB_RPC_URLS`
+ * `SOL_RPC_URLS`
+ * `BTC_ESPLORA_URLS`
 
 ```bash
 docker run -it --rm -p 3000:3000 -e PRIVATE_API_ADDR=https://api.example.com -e PRIVATE_API_AUTH=verysecretpassword ecency/api:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,13 @@ services:
       - SEARCH_API_ADDR
       - SEARCH_API_SECRET
       - STRIPE_INTERNAL_SECRET
-      - CHAINSTACK_API_KEY
-      - CHAINZ_API_KEY
       - BLOCKSTREAM_CLIENT_ID
       - BLOCKSTREAM_CLIENT_SECRET
+      - HELIUS_API_KEY
+      - ETH_RPC_URLS
+      - BNB_RPC_URLS
+      - SOL_RPC_URLS
+      - BTC_ESPLORA_URLS
     ports:
       - "4000:4000"
     networks:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@hiveio/dhive": "^1.2.7",
     "axios": "^1.7.3",
-    "bs58check": "^4.0.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "hivesigner": "^3.2.5",

--- a/src/server/chain-providers.ts
+++ b/src/server/chain-providers.ts
@@ -54,13 +54,15 @@ export const BNB_RPC_POOL: RpcProvider[] = poolFromEnv("BNB_RPC_URLS") || [
 ];
 
 const heliusKey = (process.env.HELIUS_API_KEY || "").trim();
+const heliusRpcUrl = (apiKey: string): string =>
+    `https://mainnet.helius-rpc.com/?api-key=${encodeURIComponent(apiKey)}`;
 
 export const SOL_RPC_POOL: RpcProvider[] = poolFromEnv("SOL_RPC_URLS") || [
     { id: "publicnode", url: "https://solana-rpc.publicnode.com" },
     { id: "solana-foundation", url: "https://api.mainnet.solana.com" },
-    // Pass the Helius key as a bearer header, not a URL query param, so it stays out of logs.
+    // Helius RPC authenticates with the api-key query parameter.
     ...(heliusKey
-        ? [{ id: "helius", url: "https://mainnet.helius-rpc.com/", headers: { Authorization: `Bearer ${heliusKey}` } }]
+        ? [{ id: "helius", url: heliusRpcUrl(heliusKey) }]
         : []),
 ];
 

--- a/src/server/chain-providers.ts
+++ b/src/server/chain-providers.ts
@@ -1,0 +1,100 @@
+// Static pools of public endpoints per supported chain, ordered by preference.
+// Each pool can be overridden without a code change via a comma-separated env
+// var (ETH_RPC_URLS, BNB_RPC_URLS, SOL_RPC_URLS, BTC_ESPLORA_URLS).
+
+export interface RpcProvider {
+    id: string;
+    url: string;
+}
+
+export interface EsploraProvider {
+    id: string;
+    url: string;
+    // Authenticate with the Blockstream enterprise OAuth token (BLOCKSTREAM_CLIENT_ID/SECRET)
+    bearerAuth?: boolean;
+}
+
+const hostnameId = (url: string): string => {
+    try {
+        return new URL(url).hostname;
+    } catch (err) {
+        return url;
+    }
+};
+
+const poolFromEnv = (envName: string): RpcProvider[] | null => {
+    const raw = process.env[envName];
+
+    if (!raw) {
+        return null;
+    }
+
+    const providers = raw
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map((url) => ({ id: hostnameId(url), url }));
+
+    return providers.length > 0 ? providers : null;
+};
+
+export const ETH_RPC_POOL: RpcProvider[] = poolFromEnv("ETH_RPC_URLS") || [
+    { id: "publicnode", url: "https://ethereum-rpc.publicnode.com" },
+    { id: "drpc", url: "https://eth.drpc.org" },
+    { id: "mevblocker", url: "https://rpc.mevblocker.io" },
+];
+
+export const BNB_RPC_POOL: RpcProvider[] = poolFromEnv("BNB_RPC_URLS") || [
+    { id: "publicnode", url: "https://bsc-rpc.publicnode.com" },
+    { id: "bnbchain", url: "https://bsc-dataseed.bnbchain.org" },
+    { id: "defibit", url: "https://bsc-dataseed1.defibit.io" },
+];
+
+const heliusKey = (process.env.HELIUS_API_KEY || "").trim();
+
+export const SOL_RPC_POOL: RpcProvider[] = poolFromEnv("SOL_RPC_URLS") || [
+    { id: "publicnode", url: "https://solana-rpc.publicnode.com" },
+    { id: "solana-foundation", url: "https://api.mainnet.solana.com" },
+    ...(heliusKey ? [{ id: "helius", url: `https://mainnet.helius-rpc.com/?api-key=${heliusKey}` }] : []),
+];
+
+const blockstreamCredsConfigured = Boolean(
+    (process.env.BLOCKSTREAM_CLIENT_ID || "").trim() && (process.env.BLOCKSTREAM_CLIENT_SECRET || "").trim(),
+);
+
+// enterprise.blockstream.info requires the Blockstream OAuth bearer token; infer
+// it so an env override can include the enterprise endpoint without silently
+// running unauthenticated.
+const BEARER_AUTH_HOSTS = new Set(["enterprise.blockstream.info"]);
+
+const esploraProviderFromUrl = (url: string): EsploraProvider => {
+    const provider: EsploraProvider = { id: hostnameId(url), url };
+    if (BEARER_AUTH_HOSTS.has(hostnameId(url))) {
+        provider.bearerAuth = true;
+    }
+    return provider;
+};
+
+export const BTC_ESPLORA_POOL: EsploraProvider[] = (() => {
+    const rawEnv = process.env.BTC_ESPLORA_URLS;
+    if (rawEnv) {
+        const fromEnv = rawEnv
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean)
+            .map(esploraProviderFromUrl);
+        if (fromEnv.length > 0) {
+            return fromEnv;
+        }
+    }
+
+    const pool: EsploraProvider[] = [{ id: "mempool", url: "https://mempool.space/api" }];
+
+    if (blockstreamCredsConfigured) {
+        pool.push({ id: "blockstream", url: "https://enterprise.blockstream.info/api", bearerAuth: true });
+    }
+
+    pool.push({ id: "blockstream-public", url: "https://blockstream.info/api" });
+
+    return pool;
+})();

--- a/src/server/chain-providers.ts
+++ b/src/server/chain-providers.ts
@@ -5,6 +5,9 @@
 export interface RpcProvider {
     id: string;
     url: string;
+    // Extra request headers (e.g. an Authorization bearer for a keyed endpoint),
+    // kept out of the URL so credentials never land in access logs or error traces.
+    headers?: Record<string, string>;
 }
 
 export interface EsploraProvider {
@@ -55,7 +58,10 @@ const heliusKey = (process.env.HELIUS_API_KEY || "").trim();
 export const SOL_RPC_POOL: RpcProvider[] = poolFromEnv("SOL_RPC_URLS") || [
     { id: "publicnode", url: "https://solana-rpc.publicnode.com" },
     { id: "solana-foundation", url: "https://api.mainnet.solana.com" },
-    ...(heliusKey ? [{ id: "helius", url: `https://mainnet.helius-rpc.com/?api-key=${heliusKey}` }] : []),
+    // Pass the Helius key as a bearer header, not a URL query param, so it stays out of logs.
+    ...(heliusKey
+        ? [{ id: "helius", url: "https://mainnet.helius-rpc.com/", headers: { Authorization: `Bearer ${heliusKey}` } }]
+        : []),
 ];
 
 const blockstreamCredsConfigured = Boolean(

--- a/src/server/handlers/constants.ts
+++ b/src/server/handlers/constants.ts
@@ -78,11 +78,8 @@ export const ASSET_ICON_URLS = {
         SPK_PLACEHOLDER: "https://images.ecency.com/DQmbUoMBYahwwaZ795LV1T19Nm6nWQ5EpD9NCV9jqEnY92b/image_1_.png",
         ENGINE_PLACEHOLDER: "https://images.ecency.com/DQmUWpEYA5f2U9NmCEheSdzXwqQrBTL16jG6vWBJGYjUtZB/image_2_.png",
         CHAIN_PLACEHOLDER: "https://images.ecency.com/DQmNhVLfUxifjFQidjj9BN8kbTBcp36LSoqR1zYauUMnJEC/chain_placeholder.png",
-        APT: "https://images.ecency.com/DQmTsu6vT7cHEzEWuUb1ipaUGaTCUbutQebPdSU8T9T7xYm/apt.png",
         BNB: "https://images.ecency.com/DQmezqZDiHN1NKYsLBWYwvBQ1mNhypkoe5w4JPwjeC3E4xH/bnb.png",
         BTC: "https://images.ecency.com/DQmPKC8rkqjCdMLMtwayQ81Mj62pjVBj81ZZoZBVdiJSeeH/btc.png",
         SOL: "https://images.ecency.com/DQmZJJmjz38nQGwNDG7Fuo6dHbS6P29SN7FcNy1RcSbWaj1/solana.png",
-        ETH: "https://images.ecency.com/DQmebRVg81CP1kMeSEsMm8JHDMCu5Vkac5ndUHH4ppGSFU6/eth.png",
-        TON: "https://images.ecency.com/DQmZtTj5WKqc15LkcVmXai3aTD1vnXnvcj1U48cud4R4CsY/ton.png",
-        TRON: "https://images.ecency.com/DQmYAZQN9Jd8NbTC3fGxynpioX45LSpPG8KEbyxwYJ3dWRb/tron.png"
+        ETH: "https://images.ecency.com/DQmebRVg81CP1kMeSEsMm8JHDMCu5Vkac5ndUHH4ppGSFU6/eth.png"
 }

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import hs from "hivesigner";
-import axios, { AxiosRequestConfig } from "axios";
+import axios from "axios";
 import { cryptoUtils, Signature, Client } from '@hiveio/dhive'
 
 import { announcements } from "./announcements";
@@ -9,21 +9,22 @@ import {
     apiRequest,
     getPromotedEntries,
     ChainBalanceResponse,
-    BalanceProvider,
-    parseBalanceProvider,
-    fetchChainzBalance,
-    fetchBlockstreamBalance,
-    ensureAuthKeyInPath,
-    getBlockstreamAccessToken,
-    BLOCKSTREAM_API_BASE,
+    fetchEsploraBalance,
 } from "../helper";
+import {
+    RpcProvider,
+    EsploraProvider,
+    ETH_RPC_POOL,
+    BNB_RPC_POOL,
+    SOL_RPC_POOL,
+    BTC_ESPLORA_POOL,
+} from "../chain-providers";
 
 import { pipe } from "../util";
 import { cache } from '../cache';
 import config from "../../config";
 import { ACTIVE_PROPOSAL_META, bots } from "./constants";
 
-import bs58check from "bs58check";
 
 const client = new Client([
     "https://api.hive.blog",
@@ -178,398 +179,105 @@ export const rewardedCommunities = async (req: express.Request, res: express.Res
 
 const CHAIN_PARAM_REGEX = /^[a-z0-9-]+$/i;
 
-const CHAINSTACK_API_BASE = "https://api.chainstack.com/v1";
-const CHAINSTACK_NODES_ENDPOINT = `${CHAINSTACK_API_BASE}/nodes`;
-const CHAINSTACK_NODE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const PROVIDER_TIMEOUT_MS = 10_000;
 
-type BroadcastRequestBody = {
-    signedPayload?: unknown;
-    rawTransaction?: unknown;
-    payload?: unknown;
+const JSON_RPC_HEADERS: Record<string, string> = {
+    "Content-Type": "application/json",
 };
 
-interface ChainstackNodeDetails {
-    https_endpoint?: string;
-    wss_endpoint?: string;
-    beacon_endpoint?: string;
-    toncenter_api_v2?: string;
-    toncenter_api_v3?: string;
-    solidity_http_api_endpoint?: string;
-    auth_username?: string;
-    auth_password?: string;
-    auth_key?: string;
+// A request the client got wrong (bad address, unsupported chain). It is
+// rejected up front with its HTTP status and never reaches a provider, so it
+// must not be reported as a 502 upstream failure.
+class TerminalProviderError extends Error {
+    status: number;
+
+    constructor(message: string, status = 400) {
+        super(message);
+        this.name = "TerminalProviderError";
+        this.status = status;
+    }
 }
 
-interface ChainstackNode {
-    id: string;
-    name: string;
-    network: string;
-    provider: string;
-    status: string;
-    details: ChainstackNodeDetails;
-}
+// Try each provider in the pool in order until one succeeds; fail over on any
+// provider-side error to maximize balance availability.
+const tryProviders = async <P extends { id: string }, T>(
+    chain: string,
+    providers: P[],
+    operation: string,
+    fn: (provider: P) => Promise<T>,
+): Promise<T> => {
+    let lastError: unknown = new Error(`No ${operation} providers configured for ${chain}`);
 
-interface ChainstackNodeResponse {
-    results?: ChainstackNode[];
-}
-
-interface AxiosAuthConfig {
-    username: string;
-    password: string;
-}
-
-interface AxiosNodeConfig {
-    headers: Record<string, string>;
-    auth?: AxiosAuthConfig;
-}
-
-interface ChainBroadcastResponse {
-    chain: string;
-    txId?: string;
-    raw: unknown;
-    nodeId: string;
-    provider: "chainstack";
-}
-
-interface ChainHandler {
-    validateAddress?: (address: string) => boolean;
-    selectNode: (nodes: ChainstackNode[]) => ChainstackNode | null;
-    fetchBalance: (node: ChainstackNode, address: string) => Promise<ChainBalanceResponse>;
-}
-
-interface ChainBroadcastHandler {
-    normalizePayload?: (payload: unknown) => unknown;
-    selectNode: (nodes: ChainstackNode[]) => ChainstackNode | null;
-    broadcast: (node: ChainstackNode, payload: unknown) => Promise<ChainBroadcastResponse>;
-}
-
-let cachedNodes: ChainstackNode[] | null = null;
-let nodesCacheExpiry = 0;
-
-const buildNodeAxiosConfig = (
-    node: ChainstackNode,
-    opts?: { noAuthHeaders?: boolean }
-): AxiosNodeConfig => {
-    const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-    };
-
-    let auth: AxiosAuthConfig | undefined;
-
-    if (!opts?.noAuthHeaders) {
-        if (node.details?.auth_key) {
-            headers["x-api-key"] = node.details.auth_key;
-        }
-        const hasBasicAuth = node.details?.auth_username && node.details?.auth_password;
-        if (hasBasicAuth) {
-            auth = {
-                username: node.details!.auth_username as string,
-                password: node.details!.auth_password as string,
-            };
-        }
-    }
-
-    return { headers, auth };
-};
-
-
-const fetchChainstackNodes = async (): Promise<ChainstackNode[]> => {
-    const apiKey = process.env.CHAINSTACK_API_KEY;
-
-    if (!apiKey) {
-        throw new Error("Chainstack API key is not configured");
-    }
-
-    const now = Date.now();
-
-    if (cachedNodes && now < nodesCacheExpiry) {
-        return cachedNodes;
-    }
-
-    try {
-        const response = await axios.get<ChainstackNodeResponse>(CHAINSTACK_NODES_ENDPOINT, {
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-            },
-        });
-
-        const nodes = (response.data?.results || []).filter((node) => node.status === "running");
-
-        cachedNodes = nodes;
-        nodesCacheExpiry = now + CHAINSTACK_NODE_CACHE_TTL_MS;
-
-        return nodes;
-    } catch (err) {
-        console.error("Failed to fetch Chainstack nodes", err);
-        throw new Error("Unable to fetch Chainstack nodes");
-    }
-};
-
-const extractSignedPayload = (body: BroadcastRequestBody | undefined): unknown => {
-    if (!body || typeof body !== "object") return undefined;
-
-    const { signedPayload, rawTransaction, payload } = body;
-
-    if (signedPayload !== undefined) return signedPayload;
-    if (rawTransaction !== undefined) return rawTransaction;
-    return payload;
-};
-
-const endpointIncludes = (node: ChainstackNode, needle: string) => {
-    const loweredNeedle = needle.toLowerCase();
-    const candidates = [
-        node.details?.https_endpoint,
-        node.details?.wss_endpoint,
-        node.details?.beacon_endpoint,
-    ].filter(Boolean) as string[];
-
-    return candidates.some((candidate) => candidate.toLowerCase().includes(loweredNeedle));
-};
-
-const ensureHttpsEndpoint = (node: ChainstackNode): string => {
-    const endpoint = node.details?.https_endpoint;
-
-    if (!endpoint) {
-        throw new Error(`Node ${node.id} does not expose an HTTPS endpoint`);
-    }
-
-    return endpoint;
-};
-
-const coercePayloadBuffer = (value: unknown): Buffer | null => {
-    if (typeof value === "string") {
-        return null;
-    }
-
-    if (Buffer.isBuffer(value)) {
-        return value;
-    }
-
-    if (value instanceof Uint8Array) {
-        return Buffer.from(value);
-    }
-
-    if (value instanceof ArrayBuffer) {
-        return Buffer.from(new Uint8Array(value));
-    }
-
-    if (Array.isArray(value) && value.every((entry) => Number.isInteger(entry) && entry >= 0 && entry <= 255)) {
-        return Buffer.from(value as number[]);
-    }
-
-    return null;
-};
-
-const normalizeHexPayload = (value: unknown): string => {
-    const trimmed = typeof value === "string" ? value.trim() : "";
-    const hexFromString = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed;
-
-    const buffer = coercePayloadBuffer(value);
-    const hexFromBuffer = buffer ? buffer.toString("hex") : "";
-
-    const normalized = hexFromString || hexFromBuffer;
-
-    if (!normalized) {
-        throw new Error("Signed payload must be a hex-encoded string or byte array");
-    }
-
-    if (!/^[a-fA-F0-9]+$/.test(normalized) || normalized.length % 2 !== 0) {
-        throw new Error("Signed payload must be a hex-encoded string");
-    }
-
-    return `0x${normalized}`;
-};
-
-const normalizeBase64Payload = (value: unknown): string => {
-    const trimmed = typeof value === "string" ? value.trim() : "";
-    const buffer = coercePayloadBuffer(value);
-
-    if (!trimmed && !buffer) {
-        throw new Error("Signed payload must be a base64 string or byte array");
-    }
-
-    if (buffer) {
-        if (buffer.length === 0) {
-            throw new Error("Signed payload must not be empty");
-        }
-        return buffer.toString("base64");
-    }
-
-    try {
-        const buf = Buffer.from(trimmed, "base64");
-        if (buf.length === 0) {
-            throw new Error("Empty payload");
-        }
-    } catch (err) {
-        throw new Error("Signed payload must be valid base64");
-    }
-
-    return trimmed;
-};
-
-const normalizeAptosPayload = (value: unknown): string => {
-    if (typeof value === "string") {
-        const trimmed = value.trim();
-        if (!trimmed) {
-            throw new Error("Aptos payload must not be empty");
-        }
-        // Validate it's valid JSON
+    for (const provider of providers) {
         try {
-            JSON.parse(trimmed);
+            return await fn(provider);
         } catch (err) {
-            throw new Error("Aptos payload must be valid JSON");
-        }
-        return trimmed;
-    }
-
-    if (value && typeof value === "object") {
-        try {
-            return JSON.stringify(value);
-        } catch (err) {
-            throw new Error("Failed to serialize Aptos payload to JSON");
+            lastError = err;
+            const detail = axios.isAxiosError(err)
+                ? `status=${err.response?.status || "none"} code=${err.code || "none"}`
+                : err instanceof Error
+                    ? err.message
+                    : String(err);
+            console.warn(`${chain} ${operation} failed on ${provider.id} (${detail}), trying next provider`);
         }
     }
 
-    throw new Error("Aptos payload must be a JSON string or object");
+    throw lastError;
 };
 
-const stripLeadingZeros = (value: string): string => {
-    const stripped = value.replace(/^0+/, "");
-    return stripped === "" ? "0" : stripped;
+// Shared JSON-RPC POST used by every EVM/SOL balance and proxy call.
+const jsonRpcPost = async (
+    provider: RpcProvider,
+    method: string,
+    params: unknown[],
+    id: string,
+    errorLabel: string,
+): Promise<any> => {
+    const response = await axios.post(
+        provider.url,
+        { jsonrpc: "2.0", id, method, params },
+        { headers: JSON_RPC_HEADERS, timeout: PROVIDER_TIMEOUT_MS },
+    );
+    const data = response.data;
+
+    if (data?.error) {
+        throw new Error(data.error?.message || errorLabel);
+    }
+
+    return data;
 };
 
-const multiplyDecimalString = (value: string, multiplier: number): string => {
-    const normalized = stripLeadingZeros(value);
+// Short-lived per-address balance cache (via the shared node-cache) plus an
+// in-flight dedup map so concurrent requests for one address make one upstream call.
+const BALANCE_CACHE_TTL_SECONDS = 15;
+const inFlightBalance = new Map<string, Promise<ChainBalanceResponse>>();
 
-    if (multiplier === 0 || normalized === "0") {
-        return "0";
-    }
-
-    if (!Number.isInteger(multiplier) || multiplier < 0) {
-        throw new Error("Invalid multiplier for decimal conversion");
-    }
-
-    let carry = 0;
-    let result = "";
-
-    for (let index = normalized.length - 1; index >= 0; index -= 1) {
-        const digit = normalized.charCodeAt(index) - 48;
-
-        if (digit < 0 || digit > 9) {
-            throw new Error("Invalid decimal value during multiplication");
-        }
-
-        const product = digit * multiplier + carry;
-        const remainder = product % 10;
-
-        result = remainder.toString() + result;
-        carry = Math.floor(product / 10);
-    }
-
-    while (carry > 0) {
-        result = (carry % 10).toString() + result;
-        carry = Math.floor(carry / 10);
-    }
-
-    return stripLeadingZeros(result);
-};
-
-const addSmallIntToDecimalString = (value: string, addend: number): string => {
-    const normalized = stripLeadingZeros(value);
-
-    if (addend === 0) {
-        return normalized;
-    }
-
-    if (!Number.isInteger(addend) || addend < 0) {
-        throw new Error("Invalid addend for decimal conversion");
-    }
-
-    let carry = addend;
-    let result = "";
-
-    for (let index = normalized.length - 1; index >= 0; index -= 1) {
-        const digit = normalized.charCodeAt(index) - 48;
-
-        if (digit < 0 || digit > 9) {
-            throw new Error("Invalid decimal value during addition");
-        }
-
-        const sum = digit + carry;
-        result = (sum % 10).toString() + result;
-        carry = Math.floor(sum / 10);
-    }
-
-    while (carry > 0) {
-        result = (carry % 10).toString() + result;
-        carry = Math.floor(carry / 10);
-    }
-
-    return stripLeadingZeros(result);
-};
-
-const hexToDecimalString = (value: string): string => {
-    const normalized = stripLeadingZeros(value.toLowerCase());
-
-    if (normalized === "0") {
-        return "0";
-    }
-
-    let result = "0";
-
-    for (const char of normalized) {
-        const digit = parseInt(char, 16);
-
-        if (Number.isNaN(digit)) {
-            throw new Error("Invalid hexadecimal balance response");
-        }
-
-        result = multiplyDecimalString(result, 16);
-
-        if (digit !== 0) {
-            result = addSmallIntToDecimalString(result, digit);
-        }
-    }
-
-    return stripLeadingZeros(result);
-};
+const balanceCacheKey = (chain: string, address: string) => `chain-balance:${chain}:${address}`;
 
 const parseHexBalance = (value: unknown): string => {
     if (typeof value !== "string") {
         throw new Error("Invalid hexadecimal balance response");
     }
 
-    try {
-        const normalized = value.startsWith("0x") ? value.slice(2) : value;
+    const normalized = value.startsWith("0x") || value.startsWith("0X") ? value.slice(2) : value;
 
-        if (normalized === "") {
-            return "0";
-        }
-
-        return hexToDecimalString(normalized);
-    } catch (err) {
-        throw new Error("Failed to parse hexadecimal balance");
+    if (normalized === "") {
+        return "0";
     }
+
+    if (!/^[a-fA-F0-9]+$/.test(normalized)) {
+        throw new Error("Invalid hexadecimal balance response");
+    }
+
+    return BigInt(`0x${normalized}`).toString();
 };
 
-const fetchEvmBalance = async (chain: string, node: ChainstackNode, address: string): Promise<ChainBalanceResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-
-    const payload = {
-        jsonrpc: "2.0",
-        id: "balance",
-        method: "eth_getBalance",
-        params: [address, "latest"],
-    };
-
-    const response = await axios.post(endpoint, payload, config);
-    const data = response.data;
-
-    if (data?.error) {
-        throw new Error(data.error?.message || "EVM balance request failed");
-    }
-
+const fetchEvmBalance = async (
+    chain: string,
+    provider: RpcProvider,
+    address: string,
+): Promise<ChainBalanceResponse> => {
+    const data = await jsonRpcPost(provider, "eth_getBalance", [address, "latest"], "balance", "EVM balance request failed");
     const balance = parseHexBalance(data?.result);
 
     return {
@@ -577,59 +285,19 @@ const fetchEvmBalance = async (chain: string, node: ChainstackNode, address: str
         balance,
         unit: "wei",
         raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
+        nodeId: provider.id,
+        provider: provider.id,
     };
 };
 
-const broadcastEvmTransaction = async (
-    chain: string,
-    node: ChainstackNode,
-    signedPayload: string,
-): Promise<ChainBroadcastResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-
-    const payload = {
-        jsonrpc: "2.0",
-        id: "broadcast",
-        method: "eth_sendRawTransaction",
-        params: [signedPayload],
-    };
-
-    const response = await axios.post(endpoint, payload, config);
-    const data = response.data;
-
-    if (data?.error) {
-        throw new Error(data.error?.message || "EVM broadcast failed");
-    }
-
-    return {
-        chain,
-        txId: data?.result,
-        raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
-    };
-};
-
-const fetchSolanaBalance = async (node: ChainstackNode, address: string): Promise<ChainBalanceResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-
-    const payload = {
-        jsonrpc: "2.0",
-        id: "balance",
-        method: "getBalance",
-        params: [address, { commitment: "finalized" }],
-    };
-
-    const response = await axios.post(endpoint, payload, config);
-    const data = response.data;
-
-    if (data?.error) {
-        throw new Error(data.error?.message || "Solana balance request failed");
-    }
+const fetchSolanaBalance = async (provider: RpcProvider, address: string): Promise<ChainBalanceResponse> => {
+    const data = await jsonRpcPost(
+        provider,
+        "getBalance",
+        [address, { commitment: "finalized" }],
+        "balance",
+        "Solana balance request failed",
+    );
 
     const value = data?.result?.value;
 
@@ -642,1149 +310,57 @@ const fetchSolanaBalance = async (node: ChainstackNode, address: string): Promis
         balance: value.toString(),
         unit: "lamports",
         raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
+        nodeId: provider.id,
+        provider: provider.id,
     };
 };
 
-const broadcastSolanaTransaction = async (
-    node: ChainstackNode,
-    signedPayload: string,
-): Promise<ChainBroadcastResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-
-    const payload = {
-        jsonrpc: "2.0",
-        id: "broadcast",
-        method: "sendTransaction",
-        params: [signedPayload, { encoding: "base64" }],
-    };
-
-    const response = await axios.post(endpoint, payload, config);
-    const data = response.data;
-
-    if (data?.error) {
-        throw new Error(data.error?.message || "Solana broadcast failed");
-    }
-
-    return {
-        chain: "sol",
-        txId: data?.result,
-        raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
-    };
-};
-
-const fetchTronBalance = async (node: ChainstackNode, address: string): Promise<ChainBalanceResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-
-    let normalizedAddress = address;
-
-    if (!address.startsWith("0x")) {
-        try {
-            const decoded = bs58check.decode(address);
-            normalizedAddress = `0x${Buffer.from(decoded).toString("hex")}`;
-        } catch (err) {
-            throw new Error("Invalid Tron address provided");
-        }
-    }
-
-    const payload = {
-        jsonrpc: "2.0",
-        id: "balance",
-        method: "eth_getBalance",
-        params: [normalizedAddress, "latest"],
-    };
-
-    const response = await axios.post(endpoint, payload, config);
-    const data = response.data;
-
-    if (data?.error) {
-        throw new Error(data.error?.message || "Tron balance request failed");
-    }
-
-    const balance = parseHexBalance(data?.result);
-
-    return {
-        chain: "tron",
-        balance,
-        unit: "sun",
-        raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
-    };
-};
-
-const broadcastTronTransaction = async (
-    node: ChainstackNode,
-    signedPayload: string,
-): Promise<ChainBroadcastResponse> => {
-    const baseEndpoint =
-        node.details?.solidity_http_api_endpoint?.replace(/\/+$/, "") || ensureHttpsEndpoint(node).replace(/\/+$/, "");
-
-    const endpoint = baseEndpoint.endsWith("/jsonrpc")
-        ? baseEndpoint.slice(0, -"/jsonrpc".length)
-        : baseEndpoint;
-
-    const config = buildNodeAxiosConfig(node);
-
-    const normalizedPayload = signedPayload.startsWith("0x") ? signedPayload.slice(2) : signedPayload;
-
-    const payload = {
-        transaction: normalizedPayload,
-    };
-
-    const response = await axios.post(`${endpoint}/wallet/broadcasthex`, payload, config);
-    const data = response.data;
-
-    if (data?.result === false) {
-        const message = typeof data?.message === "string" ? data.message : undefined;
-        let decodedMessage = message;
-
-        if (message) {
-            try {
-                decodedMessage = Buffer.from(message, "base64").toString("utf8");
-            } catch (err) {
-                decodedMessage = message;
-            }
-        }
-
-        throw new Error(decodedMessage || "Tron broadcast failed");
-    }
-
-    return {
-        chain: "tron",
-        txId: data?.txid,
-        raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
-    };
-};
-
-const broadcastTonTransaction = async (
-    node: ChainstackNode,
-    signedPayload: string,
-): Promise<ChainBroadcastResponse> => {
-    const endpointCandidates = [node.details?.toncenter_api_v3, node.details?.toncenter_api_v2]
-        .filter((e): e is string => Boolean(e))
-        .map((e) => ensureAuthKeyInPath(e, node.details?.auth_key));
-
-    if (endpointCandidates.length === 0) {
-        throw new Error("TON node does not provide a Toncenter endpoint");
-    }
-
-    const headers: Record<string, string> = {
-        Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
-        "Content-Type": "application/json",
-        "User-Agent": "EcencyBalanceBot/1.0 (+https://ecency.com)",
-    };
-
-    const auth =
-        node.details?.auth_username && node.details?.auth_password
-            ? {
-                username: node.details.auth_username as string,
-                password: node.details.auth_password as string,
-            }
-            : undefined;
-
-    const apiKey = node.details?.auth_key;
-
-    // Try JSON-RPC sendBoc method
-    for (const baseEndpoint of endpointCandidates) {
-        const postTargets = new Set<string>();
-        const baseSanitized = baseEndpoint.replace(/\/+$/, "");
-        const lower = baseSanitized.toLowerCase();
-
-        if (lower.endsWith("/jsonrpc")) {
-            postTargets.add(baseSanitized);
-        } else {
-            postTargets.add(`${baseSanitized}/jsonrpc`);
-            postTargets.add(baseSanitized);
-        }
-
-        // Try both param formats for compatibility
-        const paramFormats = [
-            { boc: signedPayload },  // v3 format
-            [signedPayload],         // v2 array format
-        ];
-
-        for (const url of postTargets) {
-            for (const params of paramFormats) {
-                try {
-                    const payload = {
-                        id: "broadcast",
-                        jsonrpc: "2.0",
-                        method: "sendBoc",
-                        params,
-                    };
-
-                    const cfg: AxiosRequestConfig = {
-                        headers,
-                        auth,
-                        timeout: TON_TIMEOUT_MS,
-                        params: apiKey ? { api_key: apiKey } : undefined,
-                        validateStatus: (s) => s >= 200 && s < 500,
-                    };
-
-                    const { data, status } = await axios.post(url, payload, cfg);
-
-                    if (typeof data === "string" && /<[^>]+>/.test(data)) {
-                        continue;
-                    }
-
-                    if (data?.error) {
-                        const msg = data.error?.message || data.error;
-                        // Continue to next format if error, don't throw yet
-                        continue;
-                    }
-
-                    // Success - return result
-                    return {
-                        chain: "ton",
-                        txId: data?.result?.hash,
-                        raw: data,
-                        nodeId: node.id,
-                        provider: "chainstack",
-                    };
-                } catch (e) {
-                    if (axios.isAxiosError(e) && (e.response?.status === 404 || e.response?.status === 405)) {
-                        continue;
-                    }
-                    // Continue to next format/endpoint
-                    continue;
-                }
-            }
-        }
-    }
-
-    throw new Error("TON broadcast failed on all endpoints");
-};
-
-const broadcastAptosTransaction = async (
-    node: ChainstackNode,
-    signedPayload: string,
-): Promise<ChainBroadcastResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-    const sanitizedEndpoint = endpoint.replace(/\/+$/, "");
-    const url = `${sanitizedEndpoint}/v1/transactions`;
-
-    let parsedPayload: any;
-    try {
-        parsedPayload = JSON.parse(signedPayload);
-    } catch (err) {
-        throw new Error("Aptos payload must be valid JSON");
-    }
-
-    const response = await axios.post(url, parsedPayload, {
-        ...config,
-        headers: {
-            ...config.headers,
-            "Content-Type": "application/json",
-        },
-    });
-
-    const data = response.data;
-
-    // Check for error responses
-    if (data?.message && !data?.hash) {
-        throw new Error(data.message || "Aptos broadcast failed");
-    }
-
-    if (data?.error_code) {
-        const errorMsg = data?.message || data?.error_code;
-        throw new Error(`Aptos broadcast failed: ${errorMsg}`);
-    }
-
-    if (!data?.hash) {
-        throw new Error("Aptos broadcast failed: no transaction hash returned");
-    }
-
-    return {
-        chain: "apt",
-        txId: data.hash,
-        raw: data,
-        nodeId: node.id,
-        provider: "chainstack",
-    };
-};
-
-const requestToncenterBalance = async (
-    baseEndpoint: string,
-    address: string,
-    headers: Record<string, string>,
-    auth?: AxiosAuthConfig,
-    apiKey?: string,
-) => {
-    const sanitizedBase = baseEndpoint.replace(/\/+$/, "");
-    const baseLower = sanitizedBase.toLowerCase();
-    const restBase = baseLower.endsWith("/jsonrpc")
-        ? sanitizedBase.slice(0, -"/jsonrpc".length)
-        : sanitizedBase;
-
-    const baseConfig: AxiosRequestConfig = {
-        headers,
-        auth,
-    };
-
-    const queryParams = {
-        address,
-        ...(apiKey ? { api_key: apiKey } : {}),
-    };
-
-    const attempts: Array<() => Promise<any>> = [];
-
-    const buildGetConfig = (extraParams?: Record<string, string>): AxiosRequestConfig => ({
-        ...baseConfig,
-        params: {
-            ...queryParams,
-            ...(extraParams || {}),
-        },
-    });
-
-    if (restBase) {
-        attempts.push(() => axios.get(`${restBase}/getAddressBalance`, buildGetConfig()));
-        attempts.push(() => axios.get(restBase, buildGetConfig({ method: "getAddressBalance" })));
-    }
-
-    const postConfig: AxiosRequestConfig = {
-        ...baseConfig,
-        headers: {
-            ...headers,
-            "Content-Type": "application/json",
-        },
-    };
-
-    if (apiKey) {
-        postConfig.params = { api_key: apiKey };
-    }
-
-    const postEndpoints = new Set<string>();
-    postEndpoints.add(sanitizedBase);
-
-    if (!baseLower.endsWith("/jsonrpc")) {
-        postEndpoints.add(`${sanitizedBase}/jsonRPC`);
-    } else if (restBase) {
-        postEndpoints.add(restBase);
-    }
-
-    for (const endpoint of Array.from(postEndpoints).reverse()) {
-        attempts.unshift(() =>
-            axios.post(
-                endpoint,
-                {
-                    id: "balance",
-                    jsonrpc: "2.0",
-                    method: "getAddressBalance",
-                    params: [{ address }],
-                },
-                postConfig,
-            ),
-        );
-    }
-
-    let lastError: unknown = null;
-
-    for (const attempt of attempts) {
-        try {
-            const response = await attempt();
-            return response.data;
-        } catch (error) {
-            if (
-                axios.isAxiosError(error) &&
-                (error.response?.status === 404 || error.response?.status === 405)
-            ) {
-                lastError = error;
-                continue;
-            }
-
-            throw error;
-        }
-    }
-
-    if (lastError) {
-        throw lastError;
-    }
-
-    throw new Error("Unable to fetch TON balance from Toncenter endpoint");
-};
-
-const extractTonBalanceValue = (value: unknown, seen: Set<unknown> = new Set()): string | null => {
-    if (typeof value === "string") return value;
-    if (typeof value === "number") return Number.isFinite(value) ? String(value) : null;
-    if (Array.isArray(value)) {
-        for (const entry of value) {
-            const got = extractTonBalanceValue(entry, seen);
-            if (got !== null) return got;
-        }
-        return null;
-    }
-    if (value && typeof value === "object") {
-        if (seen.has(value)) return null;
-        seen.add(value);
-        const obj = value as Record<string, unknown>;
-        // common toncenter / tonapi fields
-        for (const k of ["balance", "result", "address_balance", "account_balance", "available_balance"]) {
-            if (k in obj) {
-                const got = extractTonBalanceValue(obj[k], seen);
-                if (got !== null) return got;
-            }
-        }
-        // nested address forms
-        if (obj.address && typeof obj.address === "object") {
-            const got = extractTonBalanceValue((obj.address as any).balance, seen);
-            if (got !== null) return got;
-        }
-    }
-    return null;
-};
-
-const ensureTonAuthKeyInEndpoint = (endpoint: string, authKey?: string): string => {
-    if (!authKey) {
-        return endpoint;
-    }
-
-    try {
-        const url = new URL(endpoint);
-
-        if (!url.hostname.endsWith(".chainstack.com")) {
-            return endpoint;
-        }
-
-        const segments = url.pathname.split("/").filter(Boolean);
-
-        if (segments[0] === authKey) {
-            return endpoint;
-        }
-
-        url.pathname = `/${[authKey, ...segments].join("/")}`;
-
-        return url.toString();
-    } catch (err) {
-        return endpoint;
-    }
-};
-
-const TON_TIMEOUT_MS = 10000;
-
-const fetchTonBalance = async (node: ChainstackNode, address: string): Promise<ChainBalanceResponse> => {
-    // Build candidate endpoints (v3 first), inject path auth key if needed
-    const endpointCandidates = [node.details?.toncenter_api_v3, node.details?.toncenter_api_v2]
-        .filter((e): e is string => Boolean(e))
-        .map((e) => ensureAuthKeyInPath(e, node.details?.auth_key));
-
-    if (endpointCandidates.length === 0) {
-        throw new Error("TON node does not provide a Toncenter endpoint");
-    }
-
-    // Common headers (avoid only-header auth; toncenter prefers api_key query)
-    const headers: Record<string, string> = {
-        Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
-        "Content-Type": "application/json",
-        "User-Agent": "EcencyBalanceBot/1.0 (+https://ecency.com)",
-    };
-
-    // Basic auth if present
-    const auth =
-        node.details?.auth_username && node.details?.auth_password
-            ? {
-                username: node.details.auth_username as string,
-                password: node.details.auth_password as string,
-            }
-            : undefined;
-
-    const apiKey = node.details?.auth_key; // chainstack toncenter often wants this as ?api_key=
-
-    const doJsonRpc = async (base: string) => {
-        // v3: many endpoints expose /jsonrpc; support both base and /jsonrpc
-        const postTargets = new Set<string>();
-        const baseSanitized = base.replace(/\/+$/, "");
-        const lower = baseSanitized.toLowerCase();
-        if (lower.endsWith("/jsonrpc")) {
-            postTargets.add(baseSanitized);
-        } else {
-            postTargets.add(`${baseSanitized}/jsonrpc`);
-            postTargets.add(baseSanitized); // some setups accept JSON-RPC at root
-        }
-
-        const body = {
-            id: "balance",
-            jsonrpc: "2.0",
-            method: "getAddressBalance",
-            params: [{ address }],
-        };
-
-        for (const url of postTargets) {
-            try {
-                const cfg: AxiosRequestConfig = {
-                    headers,
-                    auth,
-                    timeout: TON_TIMEOUT_MS,
-                    params: apiKey ? { api_key: apiKey } : undefined,
-                    validateStatus: (s) => s >= 200 && s < 500,
-                };
-                const { data, status } = await axios.post(url, body, cfg);
-
-                // reject HTML/text
-                if (typeof data === "string" && /<[^>]+>/.test(data)) {
-                    throw new Error(`HTML from toncenter (JSON-RPC) status=${status}`);
-                }
-
-                if (data?.error) {
-                    // common errors: invalid address, not initialized
-                    const msg = data.error?.message || data.error;
-                    throw new Error(String(msg || "toncenter JSON-RPC error"));
-                }
-
-                const bal = extractTonBalanceValue(data?.result ?? data);
-                if (bal === null) throw new Error("Invalid TON balance response (JSON-RPC)");
-                return { raw: data, balance: String(bal) };
-            } catch (e) {
-                // try next post target
-                continue;
-            }
-        }
-        throw new Error("toncenter JSON-RPC attempts failed");
-    };
-
-    const doRest = async (base: string) => {
-        const baseSanitized = base.replace(/\/+$/, "");
-        const baseLower = baseSanitized.toLowerCase();
-        // Try canonical REST path first
-        const rest = baseLower.endsWith("/jsonrpc") ? baseSanitized.slice(0, -"/jsonrpc".length) : baseSanitized;
-
-        const mkCfg = (extra: Record<string, string> = {}) =>
-            ({
-                headers,
-                auth,
-                timeout: TON_TIMEOUT_MS,
-                params: apiKey ? { api_key: apiKey, ...extra } : extra,
-                validateStatus: (s: number) => s >= 200 && s < 500,
-            } as AxiosRequestConfig);
-
-        // (1) /getAddressBalance?address=...
-        try {
-            const { data, status } = await axios.get(`${rest}/getAddressBalance`, mkCfg({ address }));
-            if (typeof data === "string" && /<[^>]+>/.test(data)) {
-                throw new Error(`HTML from toncenter (REST) status=${status}`);
-            }
-            const bal = extractTonBalanceValue(data);
-            if (bal !== null) return { raw: data, balance: String(bal) };
-        } catch (_) { /* pass */ }
-
-        // (2) GET rest?method=getAddressBalance&address=...
-        try {
-            const { data, status } = await axios.get(rest, mkCfg({ method: "getAddressBalance", address }));
-            if (typeof data === "string" && /<[^>]+>/.test(data)) {
-                throw new Error(`HTML from toncenter (REST-query) status=${status}`);
-            }
-            const bal = extractTonBalanceValue(data);
-            if (bal !== null) return { raw: data, balance: String(bal) };
-        } catch (_) { /* pass */ }
-
-        throw new Error("toncenter REST attempts failed");
-    };
-
-    // Try v3 JSON-RPC first, then REST, across all provided endpoints
-    let lastErr: unknown = null;
-    for (const ep of endpointCandidates) {
-        try {
-            const r = await doJsonRpc(ep);
-            return {
-                chain: "ton",
-                balance: r.balance,
-                unit: "nanotons",
-                raw: r.raw,
-                nodeId: node.id,
-                provider: "chainstack",
-            };
-        } catch (e) {
-            lastErr = e;
-            // try REST for same endpoint
-            try {
-                const r2 = await doRest(ep);
-                return {
-                    chain: "ton",
-                    balance: r2.balance,
-                    unit: "nanotons",
-                    raw: r2.raw,
-                    nodeId: node.id,
-                    provider: "chainstack",
-                };
-            } catch (e2) {
-                lastErr = e2;
-                // move on to next candidate
-            }
-        }
-    }
-
-    // Optional: public TONAPI fallback (best-effort)
-    try {
-        const tonapiKey = process.env.TONAPI_KEY?.trim();
-        const { data } = await axios.get(
-            `https://tonapi.io/v2/accounts/${encodeURIComponent(address)}`,
-            {
-                timeout: TON_TIMEOUT_MS,
-                headers: tonapiKey ? { Authorization: `Bearer ${tonapiKey}` } : undefined,
-                validateStatus: (s) => s >= 200 && s < 500,
-            }
-        );
-        const bal = extractTonBalanceValue(data);
-        if (bal !== null) {
-            return {
-                chain: "ton",
-                balance: String(bal),
-                unit: "nanotons",
-                raw: data,
-                nodeId: node.id,
-                provider: "other",
-            };
-        }
-    } catch (e3) {
-        lastErr = e3;
-    }
-
-    // If we got here, everything failed
-    if (lastErr instanceof Error) throw lastErr;
-    throw new Error("Unable to fetch TON balance from any endpoint");
-};
-
-
-const normalizeAptosAddress = (address: string): string => {
-    const trimmed = address.trim();
-    const withoutPrefix = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed;
-
-    if (!/^[0-9a-fA-F]*$/.test(withoutPrefix)) {
-        throw new Error("Invalid Aptos address provided");
-    }
-
-    const normalizedHex = withoutPrefix.replace(/^0+/, "");
-    const evenLengthHex = normalizedHex.length % 2 === 0 ? normalizedHex : `0${normalizedHex}`;
-
-    if (evenLengthHex.length > 64) {
-        throw new Error("Aptos address length exceeds 32 bytes");
-    }
-
-    const padded = evenLengthHex.padStart(64, "0");
-
-    return `0x${padded.toLowerCase()}`;
-};
-
-const fetchAptosBalance = async (node: ChainstackNode, address: string): Promise<ChainBalanceResponse> => {
-    const endpoint = ensureHttpsEndpoint(node);
-    const config = buildNodeAxiosConfig(node);
-    const normalizedAddress = normalizeAptosAddress(address);
-    const resourceType = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
-    const sanitizedEndpoint = endpoint.replace(/\/+$/, "");
-    const url = `${sanitizedEndpoint}/v1/accounts/${normalizedAddress}/resource/${encodeURIComponent(resourceType)}`;
-
-    try {
-        const response = await axios.get(url, config);
-        const data = response.data;
-        const balance = data?.data?.coin?.value;
-
-        if (typeof balance !== "string") {
-            throw new Error("Invalid Aptos balance response");
-        }
-
-        return {
-            chain: "apt",
-            balance,
-            unit: "octas",
-            raw: data,
-            nodeId: node.id,
-            provider: "chainstack",
-        };
-    } catch (err) {
-        if (axios.isAxiosError(err) && err.response?.status === 404) {
-            try {
-                const viewUrl = `${sanitizedEndpoint}/v1/view`;
-                const viewPayload = {
-                    function: "0x1::coin::balance",
-                    type_arguments: ["0x1::aptos_coin::AptosCoin"],
-                    arguments: [normalizedAddress],
-                };
-
-                const viewResponse = await axios.post(viewUrl, viewPayload, config);
-                const viewData = viewResponse.data;
-                const [viewBalance] = Array.isArray(viewData) ? viewData : [];
-                const balance =
-                    typeof viewBalance === "string"
-                        ? viewBalance
-                        : typeof viewBalance === "number"
-                            ? viewBalance.toString()
-                            : null;
-
-                if (balance !== null) {
-                    return {
-                        chain: "apt",
-                        balance,
-                        unit: "octas",
-                        raw: viewData,
-                        nodeId: node.id,
-                        provider: "chainstack",
-                    };
-                }
-            } catch (viewError) {
-                if (!axios.isAxiosError(viewError) || viewError.response?.status !== 404) {
-                    throw viewError;
-                }
-            }
-
-            return {
-                chain: "apt",
-                balance: "0",
-                unit: "octas",
-                raw: err.response?.data,
-                nodeId: node.id,
-                provider: "chainstack",
-            };
-        }
-
-        throw err;
-    }
-};
-
-const BITCOIN_SATOSHI_PRECISION = 8;
-
-const normalizeBitcoinDecimalToSats = (value: string): string => {
-    const trimmed = value.trim();
-
-    if (trimmed === "") {
-        throw new Error("Invalid Bitcoin balance response");
-    }
-
-    let digits = trimmed;
-    let sign = "";
-
-    if (digits.startsWith("+")) {
-        digits = digits.slice(1);
-    } else if (digits.startsWith("-")) {
-        sign = "-";
-        digits = digits.slice(1);
-    }
-
-    if (digits === "" || digits === ".") {
-        throw new Error("Invalid Bitcoin balance response");
-    }
-
-    const [wholePartRaw, fractionalPartRaw = ""] = digits.split(".");
-    const wholePart = wholePartRaw === "" ? "0" : wholePartRaw;
-
-    if (!/^\d+$/.test(wholePart) || !/^\d*$/.test(fractionalPartRaw)) {
-        throw new Error("Invalid Bitcoin balance response");
-    }
-
-    let fractionalPart = fractionalPartRaw;
-
-    if (fractionalPart.length > BITCOIN_SATOSHI_PRECISION) {
-        const extra = fractionalPart.slice(BITCOIN_SATOSHI_PRECISION);
-
-        if (/[^0]/.test(extra)) {
-            throw new Error("Bitcoin balance exceeds satoshi precision");
-        }
-
-        fractionalPart = fractionalPart.slice(0, BITCOIN_SATOSHI_PRECISION);
-    }
-
-    const paddedFraction = fractionalPart.padEnd(BITCOIN_SATOSHI_PRECISION, "0");
-    const combined = stripLeadingZeros(`${wholePart}${paddedFraction}`);
-
-    if (combined === "0") {
-        return "0";
-    }
-
-    return sign === "-" ? `-${combined}` : combined;
-};
-
-const normalizeBitcoinBalanceToSats = (value: unknown): string => {
-    if (typeof value === "number") {
-        if (!Number.isFinite(value)) {
-            throw new Error("Invalid Bitcoin balance response");
-        }
-
-        if (Number.isInteger(value)) {
-            if (!Number.isSafeInteger(value)) {
-                throw new Error("Bitcoin balance exceeds numeric precision");
-            }
-
-            return value.toString();
-        }
-
-        return normalizeBitcoinDecimalToSats(value.toFixed(BITCOIN_SATOSHI_PRECISION));
-    }
-
-    if (typeof value === "string") {
-        const trimmed = value.trim();
-
-        if (trimmed === "") {
-            throw new Error("Invalid Bitcoin balance response");
-        }
-
-        if (/^-?\d+$/.test(trimmed)) {
-            return trimmed;
-        }
-
-        if (/^-?(?:\d+)?(?:\.\d+)?$/.test(trimmed)) {
-            return normalizeBitcoinDecimalToSats(trimmed);
-        }
-
-        if (/^-?(?:\d+)?(?:\.\d+)?e[-+]?\d+$/i.test(trimmed)) {
-            const numeric = Number(trimmed);
-
-            if (!Number.isFinite(numeric)) {
-                throw new Error("Invalid Bitcoin balance response");
-            }
-
-            return normalizeBitcoinBalanceToSats(numeric);
-        }
-
-        throw new Error("Invalid Bitcoin balance response");
-    }
-
-    throw new Error("Invalid Bitcoin balance response");
-};
-
-const formatBitcoinFromSats = (value: string): string => {
-    if (!/^-?\d+$/.test(value)) {
-        throw new Error("Invalid satoshi balance");
-    }
-
-    let sign = "";
-    let digits = value;
-
-    if (value.startsWith("-")) {
-        sign = "-";
-        digits = value.slice(1);
-    }
-
-    digits = stripLeadingZeros(digits);
-
-    if (digits === "0") {
-        return `${sign}0`;
-    }
-
-    if (digits.length <= 8) {
-        const fraction = digits.padStart(8, "0").replace(/0+$/, "");
-
-        if (fraction.length === 0) {
-            return `${sign}0`;
-        }
-
-        return `${sign}0.${fraction}`;
-    }
-
-    const whole = stripLeadingZeros(digits.slice(0, digits.length - 8));
-    const fraction = digits.slice(digits.length - 8).replace(/0+$/, "");
-
-    if (fraction.length === 0) {
-        return `${sign}${whole}`;
-    }
-
-    return `${sign}${whole}.${fraction}`;
-};
-
-const btcCache = new Map<string, { bestblock: string; balance: string; at: number }>();
-const BTC_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
-// De-duplicate concurrent scans per address
-const inFlightBtc = new Map<string, Promise<{ balance: string; raw: unknown }>>();
-
-const getBestBlockHash = async (endpoint: string, config: AxiosRequestConfig) => {
-    const payload = { jsonrpc: "1.0", id: "tip", method: "getbestblockhash", params: [] };
-    const { data } = await axios.post(endpoint, payload, config);
-    if (data?.error) throw new Error(data.error?.message || "getbestblockhash failed");
-    return data.result as string;
-};
-
-
-const BITCOIN_RPC_TIMEOUT_MS = 15_000;
-
-const fetchBitcoinBalance = async (node: ChainstackNode, address: string): Promise<ChainBalanceResponse> => {
-    // IMPORTANT: BTC wants the auth key in the URL path, not in headers or basic auth.
-    const baseEndpoint = ensureHttpsEndpoint(node);
-    const btcEndpoint = ensureAuthKeyInPath(baseEndpoint, node.details?.auth_key);
-
-    const config: AxiosRequestConfig = {
-        ...buildNodeAxiosConfig(node, { noAuthHeaders: true }),
-        timeout: BITCOIN_RPC_TIMEOUT_MS, // e.g. 15000
-    };
-
-    const getBestBlockHash = async (endpoint: string, cfg: AxiosRequestConfig) => {
-        try {
-            const payload = { jsonrpc: "1.0", id: "tip", method: "getbestblockhash", params: [] };
-            const { data } = await axios.post(endpoint, payload, cfg);
-            if (data?.error) throw new Error(data.error?.message || "getbestblockhash failed");
-            return data.result as string;
-        } catch (e: any) {
-            if (axios.isAxiosError(e) && (e.response?.status === 499 || e.code === "ECONNABORTED")) {
-                const err = new Error("BTC_TIP_TIMEOUT");
-                (err as any).code = "BTC_TIP_TIMEOUT";
-                throw err;
-            }
-            throw e;
-        }
-    };
-
-    const tryScanTxOutSet = async (): Promise<{ balance: string; raw: unknown }> => {
-        const tip = await getBestBlockHash(btcEndpoint, config);
-
-        const cached = btcCache.get(address);
-        if (cached && cached.bestblock === tip && Date.now() - cached.at < BTC_CACHE_TTL_MS) {
-            return { balance: cached.balance, raw: { cached: true, bestblock: tip } };
-        }
-
-        const payload = {
-            jsonrpc: "1.0",
-            id: "balance",
-            method: "scantxoutset",
-            params: ["start", [{ desc: `addr(${address})` }]],
-        };
-
-        const { data } = await axios.post(btcEndpoint, payload, config);
-        if (data?.error) {
-            const message = data.error?.message || "Bitcoin scantxoutset failed";
-            const lowered = String(message).toLowerCase();
-
-            // Existing checks...
-            if (lowered.includes("method not found") || lowered.includes("disabled") || lowered.includes("not enabled")) {
-                const err = new Error("BTC_SCAN_UNAVAILABLE");
-                (err as any).code = "BTC_SCAN_UNAVAILABLE";
-                throw err;
-            }
-
-            // NEW: global lock contention on shared node
-            if (lowered.includes("scan already in progress")) {
-                const err = new Error('BTC_SCAN_IN_PROGRESS');
-                (err as any).code = "BTC_SCAN_IN_PROGRESS";
-                throw err;
-            }
-
-            const err = new Error(`BTC_SCAN_FAILED: ${message}`);
-            (err as any).code = "BTC_SCAN_FAILED";
-            throw err;
-        }
-
-        const amount = data?.result?.total_amount;
-        const bestblock = data?.result?.bestblock;
-
-        const balance =
-            typeof amount === "number" ? amount.toString() :
-                typeof amount === "string" ? amount : null;
-
-        if (!balance || !bestblock) {
-            const err = new Error("BTC_INVALID_RESPONSE");
-            (err as any).code = "BTC_INVALID_RESPONSE";
-            throw err;
-        }
-
-        btcCache.set(address, { bestblock, balance, at: Date.now() });
-        return { balance, raw: data };
-    };
-
-    // de-dup concurrent scans
-    const key = address;
-    const existing = inFlightBtc.get(key);
-    if (existing) {
-        const result = await existing;
-        return {
-            chain: "btc",
-            balance: result.balance,
-            unit: "btc",
-            raw: result.raw,
-            nodeId: node.id,
-            provider: "chainstack",
-        };
-    }
-
-    const p = tryScanTxOutSet().finally(() => inFlightBtc.delete(key));
-    inFlightBtc.set(key, p);
-
-    const scanned = await p;
-    return {
-        chain: "btc",
-        balance: scanned.balance,
-        unit: "btc",
-        raw: scanned.raw,
-        nodeId: node.id,
-        provider: "chainstack",
-    };
-};
-
-const normalizeBitcoinPayload = (value: unknown): string => normalizeHexPayload(value).slice(2);
-
-const broadcastBitcoinViaBlockstream = async (signedPayload: string): Promise<ChainBroadcastResponse> => {
-    const token = await getBlockstreamAccessToken();
-
-    const response = await axios.post(
-        `${BLOCKSTREAM_API_BASE}/tx`,
-        signedPayload,
-        {
-            headers: {
-                Authorization: `Bearer ${token}`,
-                "Content-Type": "text/plain",
-            },
-            timeout: 15000,
-        }
-    );
-
-    const txId = typeof response.data === "string" ? response.data.trim() : response.data?.txid;
-
-    if (!txId) {
-        throw new Error("Blockstream broadcast failed: no txid returned");
-    }
-
-    return {
-        chain: "btc",
-        txId,
-        raw: response.data,
-        nodeId: "blockstream-fallback",
-        provider: "chainstack",
-    };
-};
-
-const broadcastBitcoinTransaction = async (
-    node: ChainstackNode,
-    signedPayload: string,
-): Promise<ChainBroadcastResponse> => {
-    const baseEndpoint = ensureHttpsEndpoint(node);
-    const endpoint = ensureAuthKeyInPath(baseEndpoint, node.details?.auth_key);
-
-    const config: AxiosRequestConfig = {
-        ...buildNodeAxiosConfig(node, { noAuthHeaders: true }),
-        timeout: BITCOIN_RPC_TIMEOUT_MS,
-    };
-
-    const payload = {
-        jsonrpc: "1.0",
-        id: "broadcast",
-        method: "sendrawtransaction",
-        params: [signedPayload],
-    };
-
-    try {
-        const response = await axios.post(endpoint, payload, config);
-        const data = response.data;
-
-        if (data?.error) {
-            throw new Error(data.error?.message || "Bitcoin broadcast failed");
-        }
-
-        return {
-            chain: "btc",
-            txId: data?.result,
-            raw: data,
-            nodeId: node.id,
-            provider: "chainstack",
-        };
-    } catch (primaryError) {
-        console.warn("Chainstack BTC broadcast failed, trying Blockstream fallback", primaryError);
-
-        try {
-            return await broadcastBitcoinViaBlockstream(signedPayload);
-        } catch (blockstreamError) {
-            console.error("All BTC broadcast providers failed", {
-                chainstack: primaryError,
-                blockstream: blockstreamError,
-            });
-            throw primaryError;
-        }
-    }
-};
+// Address validators double as a hard allowlist: every accepted address is a
+// safe URL path segment (no "/", ".", "%"), which blocks path-traversal into
+// other provider endpoints via the balance route.
+const EVM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const BTC_ADDRESS_REGEX = /^(bc1[a-z0-9]{6,87}|[13][a-km-zA-HJ-NP-Z1-9]{25,62})$/;
+const SOL_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+interface ChainHandler {
+    validateAddress?: (address: string) => boolean;
+    fetchBalance: (address: string) => Promise<ChainBalanceResponse>;
+}
 
 const CHAIN_HANDLERS: Record<string, ChainHandler> = {
     btc: {
-        selectNode: (nodes) => nodes.find((node) => endpointIncludes(node, "bitcoin")) ?? null,
-        fetchBalance: (node, address) => fetchBitcoinBalance(node, address),
+        validateAddress: (address) => BTC_ADDRESS_REGEX.test(address),
+        fetchBalance: (address) =>
+            tryProviders("btc", BTC_ESPLORA_POOL, "balance", (provider) => fetchEsploraBalance(provider, address)),
     },
     eth: {
-        validateAddress: (address) => /^0x[a-fA-F0-9]{40}$/.test(address),
-        selectNode: (nodes) => nodes.find((node) => endpointIncludes(node, "ethereum")) ?? null,
-        fetchBalance: (node, address) => fetchEvmBalance("eth", node, address),
+        validateAddress: (address) => EVM_ADDRESS_REGEX.test(address),
+        fetchBalance: (address) =>
+            tryProviders("eth", ETH_RPC_POOL, "balance", (provider) => fetchEvmBalance("eth", provider, address)),
     },
     bnb: {
-        validateAddress: (address) => /^0x[a-fA-F0-9]{40}$/.test(address),
-        selectNode: (nodes) => nodes.find((node) => endpointIncludes(node, "bsc")) ?? null,
-        fetchBalance: (node, address) => fetchEvmBalance("bnb", node, address),
+        validateAddress: (address) => EVM_ADDRESS_REGEX.test(address),
+        fetchBalance: (address) =>
+            tryProviders("bnb", BNB_RPC_POOL, "balance", (provider) => fetchEvmBalance("bnb", provider, address)),
     },
     sol: {
-        selectNode: (nodes) => nodes.find((node) => endpointIncludes(node, "solana")) ?? null,
-        fetchBalance: (node, address) => fetchSolanaBalance(node, address),
-    },
-    tron: {
-        selectNode: (nodes) => nodes.find((node) => endpointIncludes(node, "tron")) ?? null,
-        fetchBalance: (node, address) => fetchTronBalance(node, address),
-    },
-    ton: {
-        selectNode: (nodes) =>
-            nodes.find((node) => node.details?.toncenter_api_v2 || node.details?.toncenter_api_v3) ?? null,
-        fetchBalance: (node, address) => fetchTonBalance(node, address),
-    },
-    apt: {
-        validateAddress: (address) => {
-            if (!/^(0x)?[a-fA-F0-9]+$/.test(address)) {
-                return false;
-            }
-
-            const hex = address.startsWith("0x") ? address.slice(2) : address;
-            return hex.length % 2 === 0;
-        },
-        selectNode: (nodes) => nodes.find((node) => endpointIncludes(node, "aptos")) ?? null,
-        fetchBalance: (node, address) => fetchAptosBalance(node, address),
+        validateAddress: (address) => SOL_ADDRESS_REGEX.test(address),
+        fetchBalance: (address) =>
+            tryProviders("sol", SOL_RPC_POOL, "balance", (provider) => fetchSolanaBalance(provider, address)),
     },
 };
 
-const CHAIN_BROADCAST_HANDLERS: Record<string, ChainBroadcastHandler> = {
-    btc: {
-        normalizePayload: normalizeBitcoinPayload,
-        selectNode: CHAIN_HANDLERS.btc.selectNode,
-        broadcast: (node, payload) => broadcastBitcoinTransaction(node, payload as string),
-    },
-    eth: {
-        normalizePayload: normalizeHexPayload,
-        selectNode: CHAIN_HANDLERS.eth.selectNode,
-        broadcast: (node, payload) => broadcastEvmTransaction("eth", node, payload as string),
-    },
-    bnb: {
-        normalizePayload: normalizeHexPayload,
-        selectNode: CHAIN_HANDLERS.bnb.selectNode,
-        broadcast: (node, payload) => broadcastEvmTransaction("bnb", node, payload as string),
-    },
-    tron: {
-        normalizePayload: normalizeHexPayload,
-        selectNode: CHAIN_HANDLERS.tron.selectNode,
-        broadcast: (node, payload) => broadcastTronTransaction(node, payload as string),
-    },
-    sol: {
-        normalizePayload: normalizeBase64Payload,
-        selectNode: CHAIN_HANDLERS.sol.selectNode,
-        broadcast: (node, payload) => broadcastSolanaTransaction(node, payload as string),
-    },
-    ton: {
-        normalizePayload: normalizeBase64Payload,
-        selectNode: CHAIN_HANDLERS.ton.selectNode,
-        broadcast: (node, payload) => broadcastTonTransaction(node, payload as string),
-    },
-    apt: {
-        normalizePayload: normalizeAptosPayload,
-        selectNode: CHAIN_HANDLERS.apt.selectNode,
-        broadcast: (node, payload) => broadcastAptosTransaction(node, payload as string),
-    },
+const RPC_POOL_BY_CHAIN: Record<string, RpcProvider[]> = {
+    sol: SOL_RPC_POOL,
+    eth: ETH_RPC_POOL,
+    bnb: BNB_RPC_POOL,
 };
-
 
 /**
  * Fetches balance for a given chain and address directly (without HTTP overhead)
  * This is the core logic extracted from the balance endpoint for reuse
  */
-export const fetchChainBalance = async (
-    chain: string,
-    address: string,
-    provider: BalanceProvider = "chainstack"
-): Promise<ChainBalanceResponse> => {
+export const fetchChainBalance = async (chain: string, address: string): Promise<ChainBalanceResponse> => {
     if (!chain || !address) {
         throw new Error("Missing chain or address");
     }
@@ -1797,102 +373,37 @@ export const fetchChainBalance = async (
     const handler = CHAIN_HANDLERS[normalizedChain];
 
     if (!handler) {
-        throw new Error("Unsupported chain");
+        throw new TerminalProviderError("Unsupported chain", 400);
     }
 
-    // Ignore provider=chainz for non-BTC (but log it)
-    if (provider === "chainz" && normalizedChain !== "btc") {
-        console.warn(`provider=chainz ignored for chain=${normalizedChain}`);
-    }
-
-    if (provider === "blockstream" && normalizedChain !== "btc") {
-        console.warn(`provider=blockstream ignored for chain=${normalizedChain}`);
-    }
-
-    // Helper to try Blockstream fallback
-    const tryBlockstreamFallback = async (): Promise<ChainBalanceResponse | null> => {
-        try {
-            return await fetchBlockstreamBalance(normalizedChain, address);
-        } catch (blockstreamErr) {
-            console.error("BTC fallback to Blockstream failed:", blockstreamErr);
-            return null;
-        }
-    };
-
-    // Helper to try Chainz fallback
-    const tryChainzFallback = async (): Promise<ChainBalanceResponse | null> => {
-        try {
-            return await fetchChainzBalance(normalizedChain, address);
-        } catch (fallbackErr) {
-            console.error("BTC fallback to Chainz failed:", fallbackErr);
-            return null;
-        }
-    };
-
-    // Per-chain address validation (when provided)
     if (handler.validateAddress && !handler.validateAddress(address)) {
-        throw new Error("Invalid address format");
+        throw new TerminalProviderError("Invalid address format", 400);
     }
 
-    // If client explicitly asks for Chainz and it's BTC → go straight there
-    if (normalizedChain === "btc" && provider === "chainz") {
-        return await fetchChainzBalance(normalizedChain, address);
+    const cacheKey = balanceCacheKey(normalizedChain, address);
+
+    const cached = cache.get<ChainBalanceResponse>(cacheKey);
+    if (cached) {
+        return cached;
     }
 
-    if (normalizedChain === "btc" && provider === "blockstream") {
-        return await fetchBlockstreamBalance(normalizedChain, address);
+    const existing = inFlightBalance.get(cacheKey);
+    if (existing) {
+        return existing;
     }
 
-    // Default path: Chainstack (wrap node discovery in try/catch)
-    let node: ChainstackNode | null = null;
-    try {
-        const nodes = await fetchChainstackNodes();
-        node = handler.selectNode(nodes);
-    } catch (fetchErr) {
-        if (normalizedChain === "btc") {
-            console.error(
-                "Fetching Chainstack nodes failed; falling back to alternative providers:",
-                fetchErr,
-            );
-            const blockstreamResult = await tryBlockstreamFallback();
-            if (blockstreamResult) return blockstreamResult;
+    const pending = handler
+        .fetchBalance(address)
+        .then((response) => {
+            cache.set(cacheKey, response, BALANCE_CACHE_TTL_SECONDS);
+            return response;
+        })
+        .finally(() => {
+            inFlightBalance.delete(cacheKey);
+        });
 
-            const chainzResult = await tryChainzFallback();
-            if (chainzResult) return chainzResult;
-        }
-        throw fetchErr;
-    }
-
-    if (!node) {
-        if (normalizedChain === "btc") {
-            const blockstreamResult = await tryBlockstreamFallback();
-            if (blockstreamResult) return blockstreamResult;
-
-            const chainzResult = await tryChainzFallback();
-            if (chainzResult) return chainzResult;
-        }
-        throw new Error(`No Chainstack node available for ${normalizedChain}`);
-    }
-
-    // Try Chainstack balance
-    try {
-        return await handler.fetchBalance(node, address);
-    } catch (err: any) {
-        // BTC: fallback on ANY error (timeout, unsupported RPC, etc.)
-        if (normalizedChain === "btc") {
-            console.error("BTC Chainstack path failed, attempting fallbacks:", {
-                code: err?.code,
-                message: err?.message,
-            });
-
-            const blockstreamResult = await tryBlockstreamFallback();
-            if (blockstreamResult) return blockstreamResult;
-
-            const chainzResult = await tryChainzFallback();
-            if (chainzResult) return chainzResult;
-        }
-        throw err;
-    }
+    inFlightBalance.set(cacheKey, pending);
+    return pending;
 };
 
 export const balance = async (req: express.Request, res: express.Response) => {
@@ -1903,33 +414,24 @@ export const balance = async (req: express.Request, res: express.Response) => {
         return;
     }
 
-    const provider = parseBalanceProvider(req.query.provider);
-
-    // Slightly extend server timeouts for BTC path
-    const normalizedChain = chain.toLowerCase();
-    if (normalizedChain === "btc") {
-        const extendedTimeout = BITCOIN_RPC_TIMEOUT_MS + 30_000;
-        if (typeof req.setTimeout === "function") req.setTimeout(extendedTimeout);
-        if (typeof res.setTimeout === "function") res.setTimeout(extendedTimeout);
-    }
+    // Older clients retry with ?provider=... (e.g. chainz); the parameter is
+    // accepted and ignored — provider selection is handled by the pool.
 
     try {
-        const balanceResponse = await fetchChainBalance(chain, address, provider);
+        const balanceResponse = await fetchChainBalance(chain, address);
 
-        // Set response headers
         res.setHeader("x-provider", balanceResponse.provider);
-        if (
-            balanceResponse.provider === "blockstream" &&
-            balanceResponse.rateLimitRemaining !== undefined
-        ) {
-            res.setHeader(
-                "x-blockstream-ratelimit-remaining",
-                String(balanceResponse.rateLimitRemaining),
-            );
+        if (balanceResponse.rateLimitRemaining !== undefined) {
+            res.setHeader("x-provider-ratelimit-remaining", String(balanceResponse.rateLimitRemaining));
         }
 
         res.status(200).json(balanceResponse);
     } catch (err) {
+        if (err instanceof TerminalProviderError) {
+            res.status(err.status).json({ error: err.message });
+            return;
+        }
+
         console.error("balance(): error while fetching chain balance", err);
 
         if (axios.isAxiosError(err) && err.response) {
@@ -1952,87 +454,10 @@ export const balance = async (req: express.Request, res: express.Response) => {
     }
 };
 
-export const broadcast = async (req: express.Request, res: express.Response) => {
-    const { chain } = req.params;
-    const signedPayload = extractSignedPayload(req.body as BroadcastRequestBody);
-
-    if (!chain) {
-        res.status(400).send("Missing chain parameter");
-        return;
-    }
-
-    if (!CHAIN_PARAM_REGEX.test(chain)) {
-        res.status(400).send("Invalid chain parameter");
-        return;
-    }
-
-    const normalizedChain = chain.toLowerCase();
-    const handler = CHAIN_BROADCAST_HANDLERS[normalizedChain];
-
-    if (!handler) {
-        res.status(400).send("Unsupported chain for broadcast");
-        return;
-    }
-
-    if (typeof signedPayload === "undefined") {
-        res.status(400).send("Missing signed payload");
-        return;
-    }
-
-    let normalizedPayload: unknown = signedPayload;
-    try {
-        if (handler.normalizePayload) {
-            normalizedPayload = handler.normalizePayload(signedPayload);
-        }
-    } catch (err) {
-        res.status(400).json({ error: err instanceof Error ? err.message : "Invalid payload" });
-        return;
-    }
-
-    if (typeof normalizedPayload !== "string") {
-        res.status(400).json({ error: "Signed payload must be a string" });
-        return;
-    }
-
-    try {
-        const nodes = await fetchChainstackNodes();
-        const node = handler.selectNode(nodes);
-
-        if (!node) {
-            console.error(`No Chainstack node available for ${normalizedChain} broadcast`);
-            res.status(502).send("No Chainstack node available for requested chain");
-            return;
-        }
-
-        const response = await handler.broadcast(node, normalizedPayload);
-        res.setHeader("x-provider", "chainstack");
-        res.status(200).json(response);
-    } catch (err) {
-        console.error("broadcast(): error while submitting transaction", err);
-
-        if (axios.isAxiosError(err) && err.response) {
-            const { status, data } = err.response;
-            if (data !== undefined) {
-                if (data !== null && typeof data === "object") {
-                    res.status(status).json(data);
-                } else {
-                    res.status(status).json({ error: String(data) });
-                }
-            } else {
-                res.sendStatus(status);
-            }
-            return;
-        }
-
-        const msg = err instanceof Error ? err.message : "Unknown error";
-        res.status(502).json({ error: msg });
-    }
-};
-
 /**
  * Allowed JSON-RPC methods per chain for the RPC proxy.
- * Only read-only / transaction-building methods are allowed.
- * Signing and broadcasting should use the dedicated /broadcast endpoint.
+ * Only read-only / transaction-building methods are allowed; signing and
+ * broadcasting happen client-side (MetaMask submits the transaction directly).
  */
 const ALLOWED_RPC_METHODS: Record<string, Set<string>> = {
     sol: new Set([
@@ -2063,7 +488,7 @@ const ALLOWED_RPC_METHODS: Record<string, Set<string>> = {
 
 /**
  * Generic JSON-RPC proxy for supported chains.
- * Forwards allowed read-only RPC calls to Chainstack nodes.
+ * Forwards allowed read-only RPC calls to the configured public RPC providers.
  *
  * POST /private-api/rpc/:chain
  * Body: standard JSON-RPC payload { jsonrpc, id, method, params }
@@ -2095,27 +520,23 @@ export const chainRpc = async (req: express.Request, res: express.Response) => {
         return;
     }
 
-    const handler = CHAIN_HANDLERS[normalizedChain];
-    if (!handler) {
+    const pool = RPC_POOL_BY_CHAIN[normalizedChain];
+    if (!pool) {
         res.status(400).json({ error: "Unsupported chain" });
         return;
     }
 
     try {
-        const nodes = await fetchChainstackNodes();
-        const node = handler.selectNode(nodes);
+        const result = await tryProviders(normalizedChain, pool, "rpc", async (provider) => {
+            const response = await axios.post(provider.url, body, {
+                headers: JSON_RPC_HEADERS,
+                timeout: PROVIDER_TIMEOUT_MS,
+            });
+            return { providerId: provider.id, data: response.data };
+        });
 
-        if (!node) {
-            res.status(502).json({ error: "No Chainstack node available for requested chain" });
-            return;
-        }
-
-        const endpoint = ensureHttpsEndpoint(node);
-        const config = buildNodeAxiosConfig(node);
-
-        const response = await axios.post(endpoint, body, config);
-        res.setHeader("x-provider", "chainstack");
-        res.status(200).json(response.data);
+        res.setHeader("x-provider", result.providerId);
+        res.status(200).json(result.data);
     } catch (err) {
         console.error(`chainRpc(${normalizedChain}): error`, err);
 

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -212,6 +212,10 @@ const tryProviders = async <P extends { id: string }, T>(
         try {
             return await fn(provider);
         } catch (err) {
+            if (err instanceof TerminalProviderError) {
+                throw err;
+            }
+
             lastError = err;
             const detail = axios.isAxiosError(err)
                 ? `status=${err.response?.status || "none"} code=${err.code || "none"}`
@@ -285,6 +289,110 @@ const parseHexBalance = (value: unknown): string => {
     return BigInt(`0x${normalized}`).toString();
 };
 
+const findJsonObjectEnd = (text: string, start: number): number => {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < text.length; index += 1) {
+        const char = text[index];
+
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === "\\") {
+                escaped = true;
+            } else if (char === "\"") {
+                inString = false;
+            }
+            continue;
+        }
+
+        if (char === "\"") {
+            inString = true;
+        } else if (char === "{") {
+            depth += 1;
+        } else if (char === "}") {
+            depth -= 1;
+            if (depth === 0) {
+                return index;
+            }
+        }
+    }
+
+    return -1;
+};
+
+const extractTopLevelNumericProperty = (text: string, property: string): string | null => {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    const keyLiteral = `"${property}"`;
+
+    for (let index = 0; index < text.length; index += 1) {
+        const char = text[index];
+
+        if (inString) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === "\\") {
+                escaped = true;
+            } else if (char === "\"") {
+                inString = false;
+            }
+            continue;
+        }
+
+        if (char === "\"") {
+            if (depth === 0 && text.slice(index, index + keyLiteral.length) === keyLiteral) {
+                let cursor = index + keyLiteral.length;
+                while (/\s/.test(text[cursor] || "")) cursor += 1;
+                if (text[cursor] !== ":") {
+                    inString = true;
+                    continue;
+                }
+                cursor += 1;
+                while (/\s/.test(text[cursor] || "")) cursor += 1;
+
+                const numericMatch = text.slice(cursor).match(/^\d+/);
+                return numericMatch ? numericMatch[0] : null;
+            }
+
+            inString = true;
+        } else if (char === "{" || char === "[") {
+            depth += 1;
+        } else if (char === "}" || char === "]") {
+            depth -= 1;
+        }
+    }
+
+    return null;
+};
+
+const extractSolanaLamports = (rawText: string, parsed: any): string => {
+    if (typeof parsed?.result?.value !== "number") {
+        throw new Error("Invalid Solana balance response");
+    }
+
+    const resultMatch = rawText.match(/"result"\s*:/);
+    if (resultMatch && resultMatch.index !== undefined) {
+        const resultStart = resultMatch.index + resultMatch[0].length;
+        const objectStart = rawText.indexOf("{", resultStart);
+        if (objectStart !== -1) {
+            const objectEnd = findJsonObjectEnd(rawText, objectStart);
+            if (objectEnd !== -1) {
+                const resultObject = rawText.slice(objectStart + 1, objectEnd);
+                const rawLamports = extractTopLevelNumericProperty(resultObject, "value");
+                if (rawLamports) {
+                    return rawLamports;
+                }
+            }
+        }
+    }
+
+    return Math.trunc(parsed.result.value).toString();
+};
+
 const fetchEvmBalance = async (
     chain: string,
     provider: RpcProvider,
@@ -329,12 +437,7 @@ const fetchSolanaBalance = async (provider: RpcProvider, address: string): Promi
         throw new Error(parsed.error?.message || "Solana balance request failed");
     }
 
-    if (typeof parsed?.result?.value !== "number") {
-        throw new Error("Invalid Solana balance response");
-    }
-
-    const match = rawText.match(/"value"\s*:\s*(\d+)/);
-    const balance = match ? match[1] : Math.trunc(parsed.result.value).toString();
+    const balance = extractSolanaLamports(rawText, parsed);
 
     return {
         chain: "sol",

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -225,6 +225,19 @@ const tryProviders = async <P extends { id: string }, T>(
     throw lastError;
 };
 
+const logUpstreamError = (context: string, err: unknown) => {
+    if (axios.isAxiosError(err)) {
+        console.error(context, {
+            status: err.response?.status || "none",
+            code: err.code || "none",
+            message: err.message,
+        });
+        return;
+    }
+
+    console.error(context, err);
+};
+
 // Shared JSON-RPC POST used by every EVM/SOL balance and proxy call.
 const jsonRpcPost = async (
     provider: RpcProvider,
@@ -450,7 +463,7 @@ export const balance = async (req: express.Request, res: express.Response) => {
             return;
         }
 
-        console.error("balance(): error while fetching chain balance", err);
+        logUpstreamError("balance(): error while fetching chain balance", err);
 
         if (axios.isAxiosError(err) && err.response) {
             const { status, data } = err.response;
@@ -574,7 +587,7 @@ export const chainRpc = async (req: express.Request, res: express.Response) => {
             return;
         }
 
-        console.error(`chainRpc(${normalizedChain}): error`, err);
+        logUpstreamError(`chainRpc(${normalizedChain}): error`, err);
 
         if (axios.isAxiosError(err) && err.response) {
             const { status, data } = err.response;

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -236,7 +236,7 @@ const jsonRpcPost = async (
     const response = await axios.post(
         provider.url,
         { jsonrpc: "2.0", id, method, params },
-        { headers: JSON_RPC_HEADERS, timeout: PROVIDER_TIMEOUT_MS },
+        { headers: { ...JSON_RPC_HEADERS, ...provider.headers }, timeout: PROVIDER_TIMEOUT_MS },
     );
     const data = response.data;
 
@@ -291,25 +291,43 @@ const fetchEvmBalance = async (
 };
 
 const fetchSolanaBalance = async (provider: RpcProvider, address: string): Promise<ChainBalanceResponse> => {
-    const data = await jsonRpcPost(
-        provider,
-        "getBalance",
-        [address, { commitment: "finalized" }],
-        "balance",
-        "Solana balance request failed",
+    // Keep the raw response text: lamports is a u64 and JSON.parse would cap a
+    // balance above 2^53 as a lossy double, so read the integer from the text.
+    const response = await axios.post(
+        provider.url,
+        { jsonrpc: "2.0", id: "balance", method: "getBalance", params: [address, { commitment: "finalized" }] },
+        {
+            headers: { ...JSON_RPC_HEADERS, ...provider.headers },
+            timeout: PROVIDER_TIMEOUT_MS,
+            transformResponse: (raw) => raw,
+        },
     );
 
-    const value = data?.result?.value;
+    const rawText = typeof response.data === "string" ? response.data : "";
 
-    if (typeof value !== "number") {
+    let parsed: any;
+    try {
+        parsed = JSON.parse(rawText);
+    } catch (err) {
         throw new Error("Invalid Solana balance response");
     }
 
+    if (parsed?.error) {
+        throw new Error(parsed.error?.message || "Solana balance request failed");
+    }
+
+    if (typeof parsed?.result?.value !== "number") {
+        throw new Error("Invalid Solana balance response");
+    }
+
+    const match = rawText.match(/"value"\s*:\s*(\d+)/);
+    const balance = match ? match[1] : Math.trunc(parsed.result.value).toString();
+
     return {
         chain: "sol",
-        balance: value.toString(),
+        balance,
         unit: "lamports",
-        raw: data,
+        raw: parsed,
         nodeId: provider.id,
         provider: provider.id,
     };
@@ -529,15 +547,33 @@ export const chainRpc = async (req: express.Request, res: express.Response) => {
     try {
         const result = await tryProviders(normalizedChain, pool, "rpc", async (provider) => {
             const response = await axios.post(provider.url, body, {
-                headers: JSON_RPC_HEADERS,
+                headers: { ...JSON_RPC_HEADERS, ...provider.headers },
                 timeout: PROVIDER_TIMEOUT_MS,
             });
+
+            // A JSON-RPC error body arrives with HTTP 200; treat it as a provider
+            // failure so tryProviders advances to the next pool member (e.g. a
+            // rate-limited node returning {error:{code:-32005}}), but keep the
+            // envelope so a genuine application error can still reach the client
+            // if every provider returns one.
+            if (response.data?.error) {
+                const rpcErr: any = new Error(response.data.error?.message || "RPC error");
+                rpcErr.jsonRpcBody = response.data;
+                throw rpcErr;
+            }
+
             return { providerId: provider.id, data: response.data };
         });
 
         res.setHeader("x-provider", result.providerId);
         res.status(200).json(result.data);
     } catch (err) {
+        // Every provider returned a JSON-RPC error — pass the last envelope through verbatim.
+        if (err && typeof err === "object" && "jsonRpcBody" in err) {
+            res.status(200).json((err as any).jsonRpcBody);
+            return;
+        }
+
         console.error(`chainRpc(${normalizedChain}): error`, err);
 
         if (axios.isAxiosError(err) && err.response) {

--- a/src/server/handlers/wallet-api.ts
+++ b/src/server/handlers/wallet-api.ts
@@ -122,9 +122,6 @@ const CHAIN_CONFIG: Record<string, ChainConfig> = {
     eth: { name: "Ethereum", symbol: "ETH", decimals: 18, iconUrl: ASSET_ICON_URLS.ETH },
     bnb: { name: "BNB Chain", symbol: "BNB", decimals: 18, iconUrl: ASSET_ICON_URLS.BNB },
     sol: { name: "Solana", symbol: "SOL", decimals: 9, iconUrl: ASSET_ICON_URLS.SOL },
-    tron: { name: "Tron", symbol: "TRX", decimals: 6, aliases: ["trx"], iconUrl: ASSET_ICON_URLS.TRON },
-    ton: { name: "TON", symbol: "TON", decimals: 9, iconUrl: ASSET_ICON_URLS.TON },
-    apt: { name: "Aptos", symbol: "APT", decimals: 8, iconUrl: ASSET_ICON_URLS.APT },
 };
 
 const CHAIN_SYMBOL_LOOKUP = new Map<string, { key: string; config: ChainConfig }>();

--- a/src/server/helper.ts
+++ b/src/server/helper.ts
@@ -6,7 +6,7 @@ import config from "../config";
 
 import {baseApiRequest} from "./util";
 
-export type BalanceProvider = "chainstack" | "blockstream" | "chainz" | "other";
+import {EsploraProvider} from "./chain-providers";
 
 export interface ChainBalanceResponse {
     chain: string;
@@ -14,148 +14,13 @@ export interface ChainBalanceResponse {
     unit: string;
     raw: unknown;
     nodeId?: string;
-    provider: BalanceProvider;
+    provider: string;
     rateLimitRemaining?: number;
 }
-
-// Build per-coin endpoint: https://chainz.cryptoid.info/btc/api.dws
-const chainzEndpointFor = (coin: string) => `https://chainz.cryptoid.info/${coin}/api.dws`;
-
-interface ChainzChainConfig {
-    coin: string;
-    decimals: number;
-    unit: string;
-}
-
-const stripLeadingZeros = (value: string): string => {
-    const normalized = value.replace(/^0+/, "");
-    return normalized === "" ? "0" : normalized;
-};
-
-const convertDecimalToIntegerString = (value: string, decimals: number): string => {
-    if (!Number.isInteger(decimals) || decimals < 0) {
-        throw new Error("Invalid decimal precision provided");
-    }
-
-    const trimmed = value.trim();
-
-    if (trimmed === "") {
-        throw new Error("Invalid decimal value");
-    }
-
-    let digits = trimmed;
-    let sign = "";
-
-    if (digits.startsWith("+")) {
-        digits = digits.slice(1);
-    } else if (digits.startsWith("-")) {
-        sign = "-";
-        digits = digits.slice(1);
-    }
-
-    if (digits === "" || digits === ".") {
-        throw new Error("Invalid decimal value");
-    }
-
-    const [wholePartRaw, fractionalPartRaw = ""] = digits.split(".");
-
-    if (!/^\d*$/.test(wholePartRaw) || !/^\d*$/.test(fractionalPartRaw)) {
-        throw new Error("Invalid decimal value");
-    }
-
-    if (fractionalPartRaw.length > decimals) {
-        const truncated = fractionalPartRaw.slice(decimals);
-
-        if (/[^0]/.test(truncated)) {
-            throw new Error("Decimal value exceeds supported precision");
-        }
-    }
-
-    const paddedFractional = fractionalPartRaw.padEnd(decimals, "0").slice(0, decimals);
-    const combined = `${wholePartRaw === "" ? "0" : wholePartRaw}${paddedFractional}`;
-    const normalized = stripLeadingZeros(combined);
-
-    if (sign === "-") {
-        return `-${normalized}`;
-    }
-
-    return normalized;
-};
-
-const normalizeChainzBalance = (value: string): string => {
-    const trimmed = value.trim();
-
-    // Guard: HTML or not-a-number responses → throw a clearer error
-    if (/[<][a-z!/]/i.test(trimmed)) {
-        throw new Error("Chainz returned HTML (likely error or rate limit)");
-    }
-
-    if (trimmed === "") {
-        throw new Error("Chainz returned balance in unexpected format");
-    }
-
-    if (/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
-        return trimmed;
-    }
-
-    const scientificMatch = trimmed.match(/^([+-]?)(\d+(?:\.\d+)?)[eE]([+-]?\d+)$/);
-    if (!scientificMatch) {
-        throw new Error("Chainz returned balance in unexpected format");
-    }
-
-    const [, sign = "", significand, exponentRaw] = scientificMatch;
-    const exponent = Number(exponentRaw);
-
-    if (!Number.isFinite(exponent)) {
-        throw new Error("Chainz returned balance in unexpected format");
-    }
-
-    const [wholePartRaw, fractionalPartRaw = ""] = significand.split(".");
-    const digits = `${wholePartRaw}${fractionalPartRaw}`;
-    const decimalIndex = wholePartRaw.length + exponent;
-
-    if (decimalIndex >= digits.length) {
-        const zeros = "0".repeat(decimalIndex - digits.length);
-        return `${sign}${digits}${zeros}`;
-    }
-
-    if (decimalIndex <= 0) {
-        const zeros = "0".repeat(Math.abs(decimalIndex));
-        return `${sign}0.${zeros}${digits}`;
-    }
-
-    const whole = digits.slice(0, decimalIndex);
-    const fraction = digits.slice(decimalIndex);
-
-    if (fraction === "") {
-        return `${sign}${whole}`;
-    }
-
-    return `${sign}${whole}.${fraction}`;
-};
-
-const CHAINZ_CHAIN_CONFIG: Record<string, ChainzChainConfig> = {
-    btc: {
-        coin: "btc",
-        decimals: 8,
-        unit: "satoshi",
-    }
-};
-
-export const parseBalanceProvider = (value: unknown): BalanceProvider => {
-    if (typeof value === "string") {
-        const normalized = value.trim().toLowerCase();
-        if (normalized === "chainz") return "chainz";
-        if (normalized === "blockstream") return "blockstream";
-    }
-
-    return "chainstack";
-};
 
 const BLOCKSTREAM_TOKEN_CACHE_KEY = "blockstream:access-token";
 const BLOCKSTREAM_TOKEN_URL =
     "https://login.blockstream.com/realms/blockstream-public/protocol/openid-connect/token";
-export const BLOCKSTREAM_API_BASE = "https://enterprise.blockstream.info/api";
 
 const toBigInt = (value: unknown): bigint => {
     if (typeof value === "bigint") return value;
@@ -188,7 +53,7 @@ const parseRateLimitHeader = (headerValue: unknown): number | undefined => {
     return Number.isFinite(num) ? num : undefined;
 };
 
-export const getBlockstreamAccessToken = async (): Promise<string> => {
+const getBlockstreamAccessToken = async (): Promise<string> => {
     const cached = cache.get<string>(BLOCKSTREAM_TOKEN_CACHE_KEY);
     if (cached) return cached;
 
@@ -235,31 +100,38 @@ export const getBlockstreamAccessToken = async (): Promise<string> => {
     return accessToken;
 };
 
-export const fetchBlockstreamBalance = async (
-    chain: string,
-    address: string,
-): Promise<ChainBalanceResponse> => {
-    if (chain !== "btc") {
-        throw new Error("Blockstream balance fetcher only supports BTC");
+const ESPLORA_USER_AGENT = "EcencyBalanceBot/1.0 (+https://ecency.com)";
+
+const buildEsploraHeaders = async (provider: EsploraProvider): Promise<Record<string, string>> => {
+    const headers: Record<string, string> = {
+        "User-Agent": ESPLORA_USER_AGENT,
+    };
+
+    if (provider.bearerAuth) {
+        headers["Authorization"] = `Bearer ${await getBlockstreamAccessToken()}`;
     }
 
-    const attempt = async (token: string, allowRetry: boolean): Promise<ChainBalanceResponse> => {
-        const resp = await axios.get(`${BLOCKSTREAM_API_BASE}/address/${address}`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
+    return headers;
+};
+
+export const fetchEsploraBalance = async (
+    provider: EsploraProvider,
+    address: string,
+): Promise<ChainBalanceResponse> => {
+    const attempt = async (allowAuthRetry: boolean): Promise<ChainBalanceResponse> => {
+        const resp = await axios.get(`${provider.url}/address/${encodeURIComponent(address)}`, {
+            headers: await buildEsploraHeaders(provider),
             timeout: 10000,
             validateStatus: (status) => status >= 200 && status < 500,
         });
 
-        if (resp.status === 401 && allowRetry) {
+        if (resp.status === 401 && provider.bearerAuth && allowAuthRetry) {
             cache.del(BLOCKSTREAM_TOKEN_CACHE_KEY);
-            const refreshedToken = await getBlockstreamAccessToken();
-            return attempt(refreshedToken, false);
+            return attempt(false);
         }
 
         if (resp.status !== 200) {
-            throw new Error(`Blockstream API error (${resp.status})`);
+            throw new Error(`Esplora API error from ${provider.id} (${resp.status})`);
         }
 
         const data = resp.data ?? {};
@@ -280,91 +152,17 @@ export const fetchBlockstreamBalance = async (
             parseRateLimitHeader(resp.headers["ratelimit-remaining"]);
 
         return {
-            chain,
+            chain: "btc",
             balance: total.toString(),
             unit: "satoshi",
             raw: data,
-            provider: "blockstream" as const,
+            nodeId: provider.id,
+            provider: provider.id,
             rateLimitRemaining,
         };
     };
 
-    const token = await getBlockstreamAccessToken();
-    return attempt(token, true);
-};
-
-export const fetchChainzBalance = async (
-    chain: string,
-    address: string,
-): Promise<ChainBalanceResponse> => {
-    const cfg = CHAINZ_CHAIN_CONFIG[chain];
-    if (!cfg) throw new Error("Requested chain is not supported by Chainz provider");
-
-    const endpoint = chainzEndpointFor(cfg.coin);
-    const apiKey = process.env.CHAINZ_API_KEY?.trim();
-
-    const attempt = async (queryName: "getbalance" | "addressbalance") => {
-        const params = new URLSearchParams({ q: queryName, a: address });
-        if (apiKey) params.set("key", apiKey);
-        // You can uncomment this if needed:
-        // params.set("format", "plain");
-
-        const url = `${endpoint}?${params.toString()}`;
-        const resp = await axios.get<string | number>(url, {
-            timeout: 8000,
-            headers: {
-                "Accept": "text/plain, application/json;q=0.9, */*;q=0.8",
-                "User-Agent": "EcencyBalanceBot/1.0 (+https://ecency.com)",
-                "Cache-Control": "no-cache",
-                "Pragma": "no-cache",
-            },
-            validateStatus: (s) => s >= 200 && s < 500,
-        });
-
-        const text = String(resp.data ?? "").trim();
-
-        // bail if HTML or empty
-        if (!text || /[<][a-z!/]/i.test(text)) {
-            const status = resp.status;
-            const first = text.slice(0, 120);
-            throw new Error(`Chainz non-numeric response (${status}): ${first || "<empty>"}`);
-        }
-
-        // normalize number (supports scientific notation)
-        const raw = normalizeChainzBalance(text);
-        const normalized = convertDecimalToIntegerString(raw, cfg.decimals);
-
-        return {
-            chain,
-            balance: normalized,
-            unit: cfg.unit,
-            raw: text,
-            provider: "chainz" as const,
-        };
-    };
-
-    try {
-        return await attempt("getbalance");
-    } catch (_) {
-        // fall through to the second query name
-    }
-    return await attempt("addressbalance");
-};
-
-// Ensures the Chainstack auth_key is present as the first path segment.
-// e.g. https://bitcoin-mainnet.core.chainstack.com -> https://bitcoin-mainnet.core.chainstack.com/<AUTH_KEY>
-export const ensureAuthKeyInPath = (endpoint: string, authKey?: string): string => {
-    if (!authKey) return endpoint;
-    try {
-        const url = new URL(endpoint);
-        if (!url.hostname.endsWith(".chainstack.com")) return endpoint;
-        const segs = url.pathname.split("/").filter(Boolean);
-        if (segs[0] === authKey) return endpoint; // already there
-        url.pathname = `/${[authKey, ...segs].join("/")}`;
-        return url.toString();
-    } catch {
-        return endpoint;
-    }
+    return attempt(true);
 };
 
 

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -46,7 +46,6 @@ server
     .get("^/private-api/received-rc/:username$", privateApi.receivedRC)
     .get("^/private-api/rewarded-communities$", privateApi.rewardedCommunities)
     .get("^/private-api/balance/:chain/:address$", privateApi.balance)
-    .post("^/private-api/broadcast/:chain$", privateApi.broadcast)
     .post("^/private-api/rpc/:chain$", privateApi.chainRpc)
     .get("^/private-api/leaderboard/:duration(day|week|month)$", privateApi.leaderboard)
     .get("^/private-api/curation/:duration(day|week|month)$", privateApi.curation)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,11 +1252,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@noble/hashes@^1.2.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
-  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
-
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
@@ -2191,11 +2186,6 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
-base-x@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
-  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
-
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -2448,21 +2438,6 @@ bs58@^4.0.1:
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
     base-x "^3.0.2"
-
-bs58@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
-  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
-  dependencies:
-    base-x "^5.0.0"
-
-bs58check@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-4.0.0.tgz#46cda52a5713b7542dcb78ec2efdf78f5bf1d23c"
-  integrity sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==
-  dependencies:
-    "@noble/hashes" "^1.2.0"
-    bs58 "^6.0.0"
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Moves the external-chain balance and RPC-proxy endpoints off the Chainstack vendor onto static, ordered pools of public endpoints, each with per-provider failover. No client changes are required: `/private-api/balance/:chain/:address` keeps the same response shape (echoed `chain`, integer base-unit `balance` string, `unit`), and `/private-api/rpc/:chain` stays a transparent JSON-RPC proxy.

## Providers (all keyless by default; optional free keys only)
- **BTC** — Esplora dialect (`mempool.space`, then Blockstream), integer satoshi. This also fixes the old default path returning a decimal BTC string.
- **ETH / BNB / SOL** — public JSON-RPC pools (PublicNode plus independent operators / official dataseeds).
- Pools are overridable per environment via `ETH_RPC_URLS`, `BNB_RPC_URLS`, `SOL_RPC_URLS`, `BTC_ESPLORA_URLS` (comma-separated), so endpoints can be swapped without a code change.

## Scope reductions
- **Removed `POST /private-api/broadcast/:chain`.** Transactions are signed and broadcast client-side through MetaMask; the endpoint had no consumers.
- **Removed TRON / TON / APT** balance handlers and config — none are exposed in the wallet UI (BTC/ETH/BNB/SOL only).

## Hardening
- Per-chain address validation, which also rejects path-traversal attempts through the balance route and returns `400` on malformed input instead of walking the whole provider pool.
- 10s per-provider timeout, a short-lived balance cache (shared node-cache) and in-flight request dedup.
- Native `BigInt` in place of the hand-rolled hex bignum for EVM balances.

## Config / env
- Drops `CHAINSTACK_API_KEY` and the defunct Chainz BTC fallback (`CHAINZ_API_KEY`).
- `BLOCKSTREAM_CLIENT_ID/SECRET` remain optional (Blockstream enterprise BTC fallback); adds optional `HELIUS_API_KEY` as an extra Solana fallback.

Balance and RPC paths were exercised live against the new pools (correct integer balances per chain, failover on a dead primary, validation → 400, RPC proxy `getLatestBlockhash`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable RPC and Esplora endpoint lists for supported chains, including optional Blockstream and Helius authentication.
  * Improved balance and blockchain request handling with automatic provider failover and cached responses.

* **Bug Fixes**
  * Strengthened validation for chain and address inputs.
  * Made balance results more consistent and improved handling of upstream errors and rate limits.

* **Chores**
  * Updated setup documentation and deployment configuration to reflect the new environment variables.
  * Removed support for several previously listed chain configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->