### PR TITLE
Streak-freeze proxy (info + buy)

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2306,6 +2306,27 @@ export const quests = async (req: express.Request, res: express.Response) => {
     pipe(apiRequest(`users/${username}/quests`, "GET"), res);
 };
 
+// Streak Freeze buys/spends Points, so the username is taken from the authenticated
+// token (validateCode), never from the request body.
+export const streakFreeze = async (req: express.Request, res: express.Response) => {
+    const username = await validateCode(req);
+    if (!username) {
+        res.status(401).send("Unauthorized");
+        return;
+    }
+    pipe(apiRequest(`users/${username}/streak-freeze`, "GET"), res);
+};
+
+export const streakFreezeBuy = async (req: express.Request, res: express.Response) => {
+    const username = await validateCode(req);
+    if (!username) {
+        res.status(401).send("Unauthorized");
+        return;
+    }
+    const { idempotency_key } = req.body;
+    pipe(apiRequest(`users/${username}/streak-freeze`, "POST", {}, { idempotency_key }), res);
+};
+
 /**
  * Resolve the originating client IP for the account-create endpoints from the
  * proxy-set X-Real-IP header. X-Forwarded-For is not used here because it can

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -2306,24 +2306,42 @@ export const quests = async (req: express.Request, res: express.Response) => {
     pipe(apiRequest(`users/${username}/quests`, "GET"), res);
 };
 
-// Streak Freeze buys/spends Points, so the username is taken from the authenticated
-// token (validateCode), never from the request body.
-export const streakFreeze = async (req: express.Request, res: express.Response) => {
+// Resolve the authenticated username from the signed token, or send 401 and return
+// undefined. Used by the spend endpoints, which must never trust a body-supplied user.
+const requireAuthedUsername = async (
+    req: express.Request,
+    res: express.Response
+): Promise<string | undefined> => {
     const username = await validateCode(req);
     if (!username) {
         res.status(401).send("Unauthorized");
+        return undefined;
+    }
+    return username;
+};
+
+// Streak Freeze buys/spends Points, so the username is taken from the authenticated
+// token (validateCode), never from the request body.
+export const streakFreeze = async (req: express.Request, res: express.Response) => {
+    const username = await requireAuthedUsername(req, res);
+    if (!username) {
         return;
     }
     pipe(apiRequest(`users/${username}/streak-freeze`, "GET"), res);
 };
 
 export const streakFreezeBuy = async (req: express.Request, res: express.Response) => {
-    const username = await validateCode(req);
+    const username = await requireAuthedUsername(req, res);
     if (!username) {
-        res.status(401).send("Unauthorized");
         return;
     }
-    const { idempotency_key } = req.body;
+    // Require the idempotency key: a spend must never reach ePoints without it (a
+    // missing key drops from the payload and removes double-charge protection on retry).
+    const { idempotency_key } = req.body as { idempotency_key?: unknown };
+    if (typeof idempotency_key !== "string" || !idempotency_key.trim()) {
+        res.status(400).send("idempotency_key is required");
+        return;
+    }
     pipe(apiRequest(`users/${username}/streak-freeze`, "POST", {}, { idempotency_key }), res);
 };
 

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -73,6 +73,8 @@ server
     .post("^/private-api/points$", privateApi.points)
     .post("^/private-api/point-list$", privateApi.pointList)
     .post("^/private-api/quests$", privateApi.quests)
+    .post("^/private-api/streak-freeze$", privateApi.streakFreeze)
+    .post("^/private-api/streak-freeze/buy$", privateApi.streakFreezeBuy)
     .post("^/private-api/account-create$", privateApi.createAccount)
     .post("^/private-api/account-create-friend$", privateApi.createAccountFriend)
     .post("^/private-api/subscribe$", privateApi.subscribeNewsletter)


### PR DESCRIPTION
Authenticated private-api pass-through to ePoints for the Streak Freeze feature (ecency/ePoints#24).

- `POST /private-api/streak-freeze` -> ePoints `GET users/<user>/streak-freeze` (price + owned inventory)
- `POST /private-api/streak-freeze/buy` -> ePoints `POST users/<user>/streak-freeze` (`{idempotency_key}`)

Both resolve the username from the signed token via `validateCode` (never from the request body) because buying spends Points; unauthenticated requests get 401. ePoints 402 (insufficient) / 409 (max owned) statuses propagate to the client through `pipe`.

Typecheck clean. Deploy after ePoints #24 is live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated streak freeze endpoints for checking streak freeze status and purchasing streak freeze access.
  * Added new private API routes to support these actions in the app.

* **Bug Fixes**
  * Requests now return a clear `401 Unauthorized` response when authentication validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->