### PR TITLE
ci: drop decommissioned SG origin from deploy matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region: [EU, US, SG]
+        region: [EU, US]
     steps:
       - name: Deploy vision_vapi (${{ matrix.region }})
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
The SG (asia) origin was decommissioned, but the deploy matrix still targets it. Its `deploy (SG)` job fails on every push to `main` with an SSH `dial tcp: i/o timeout`, and because the matrix uses `fail-fast: false` the whole run is marked failed even though `deploy (EU)` and `deploy (US)` both succeed (this is why #40 and #41 show red despite deploying cleanly).

Drops `SG` from the matrix so it deploys only to the two live origins. No other change.