### PR TITLE
Add public /private-api/pro-members passthrough

### DIFF
--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -177,6 +177,12 @@ export const rewardedCommunities = async (req: express.Request, res: express.Res
     pipe(apiRequest(`rewarded-communities`, "GET"), res);
 };
 
+// Public list of Pro usernames for the Pro badge roster. No auth: this is a
+// public, cached list served straight from the backend.
+export const proMembers = async (req: express.Request, res: express.Response) => {
+    pipe(apiRequest(`pro-members`, "GET"), res);
+};
+
 const CHAIN_PARAM_REGEX = /^[a-z0-9-]+$/i;
 
 const PROVIDER_TIMEOUT_MS = 10_000;

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -45,6 +45,7 @@ server
     .get("^/private-api/received-vesting/:username$", privateApi.receivedVesting)
     .get("^/private-api/received-rc/:username$", privateApi.receivedRC)
     .get("^/private-api/rewarded-communities$", privateApi.rewardedCommunities)
+    .get("^/private-api/pro-members$", privateApi.proMembers)
     .get("^/private-api/balance/:chain/:address$", privateApi.balance)
     .post("^/private-api/rpc/:chain$", privateApi.chainRpc)
     .get("^/private-api/leaderboard/:duration(day|week|month)$", privateApi.leaderboard)


### PR DESCRIPTION
Adds a public, unauthenticated GET `/private-api/pro-members` that forwards to the backend `pro-members` path and returns its JSON: a cached list of Pro usernames. This lets the web and mobile clients fetch the Pro badge roster.

Mirrors the existing `rewarded-communities` GET passthrough. No auth is applied since the list is public and cached upstream.

Deploy note: the api-proxy nginx allowlist (box-local, not in this repo) must add `/pro-members` to the ePoints location group, otherwise the vapi to backend hop returns 404.