### PR TITLE
Add support-settings private-api endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "jest": "^26.0.0"
   },
   "jest": {
+    "moduleNameMapper": {
+      "^axios$": "axios/dist/node/axios.cjs"
+    },
     "transform": {
       "\\.(ts|tsx)$": "ts-jest",
       "\\.css$": "<rootDir>/node_modules/razzle/config/jest/cssTransform.js",

--- a/src/server/handlers/private-api.test.ts
+++ b/src/server/handlers/private-api.test.ts
@@ -1,4 +1,4 @@
-import { signupClientIp } from "./private-api";
+import { parseSupportSettingsPayload, signupClientIp } from "./private-api";
 
 // Minimal express.Request stand-in: signupClientIp only reads `headers`.
 const reqWith = (headers: Record<string, string | string[]>): any => ({ headers });
@@ -26,5 +26,49 @@ describe("signupClientIp", () => {
         expect(signupClientIp(reqWith({ "x-real-ip": ["198.51.100.7", "10.0.0.1"] }))).toBe(
             "198.51.100.7"
         );
+    });
+});
+
+describe("parseSupportSettingsPayload", () => {
+    it("accepts integers within 0..100", () => {
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5, curation_percent: 10 })).toEqual({
+            beneficiary_percent: 5,
+            curation_percent: 10
+        });
+    });
+
+    it("accepts the 0 and 100 boundaries", () => {
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 0, curation_percent: 100 })).toEqual({
+            beneficiary_percent: 0,
+            curation_percent: 100
+        });
+    });
+
+    it("rejects values out of range", () => {
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 101, curation_percent: 10 })).toBeNull();
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5, curation_percent: -1 })).toBeNull();
+    });
+
+    it("rejects floats", () => {
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5.5, curation_percent: 10 })).toBeNull();
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5, curation_percent: 0.1 })).toBeNull();
+    });
+
+    it("rejects strings", () => {
+        expect(parseSupportSettingsPayload({ beneficiary_percent: "5", curation_percent: 10 })).toBeNull();
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5, curation_percent: "10" })).toBeNull();
+    });
+
+    it("rejects booleans", () => {
+        expect(parseSupportSettingsPayload({ beneficiary_percent: true, curation_percent: 10 })).toBeNull();
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5, curation_percent: false })).toBeNull();
+    });
+
+    it("rejects missing fields and bodies", () => {
+        expect(parseSupportSettingsPayload({})).toBeNull();
+        expect(parseSupportSettingsPayload({ beneficiary_percent: 5 })).toBeNull();
+        expect(parseSupportSettingsPayload({ curation_percent: 5 })).toBeNull();
+        expect(parseSupportSettingsPayload(undefined)).toBeNull();
+        expect(parseSupportSettingsPayload(null)).toBeNull();
     });
 });

--- a/src/server/handlers/private-api.ts
+++ b/src/server/handlers/private-api.ts
@@ -1202,6 +1202,59 @@ export const bookmarksDelete = async (req: express.Request, res: express.Respons
     pipe(apiRequest(`bookmarks/${username}/${id}`, "DELETE"), res);
 }
 
+/**
+ * Parse and validate the support-settings payload. Both fields must be integers
+ * within 0..100 (booleans, strings and floats are rejected). Returns the parsed
+ * pair, or null when the payload is invalid. Exported for unit tests.
+ */
+export const parseSupportSettingsPayload = (
+    body: unknown
+): { beneficiary_percent: number; curation_percent: number } | null => {
+    const { beneficiary_percent, curation_percent } = (body || {}) as {
+        beneficiary_percent?: unknown;
+        curation_percent?: unknown;
+    };
+    const isPercent = (v: unknown): v is number =>
+        typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 100;
+    if (!isPercent(beneficiary_percent) || !isPercent(curation_percent)) {
+        return null;
+    }
+    return { beneficiary_percent, curation_percent };
+};
+
+// Support settings are per-user opt-ins, so the username is taken from the
+// authenticated token (validateCode), never from the request body.
+export const supportSettings = async (req: express.Request, res: express.Response) => {
+    const username = await requireAuthedUsername(req, res);
+    if (!username) {
+        return;
+    }
+    pipe(apiRequest(`support-settings/${username}`, "GET"), res);
+};
+
+export const supportSettingsUpdate = async (req: express.Request, res: express.Response) => {
+    const username = await requireAuthedUsername(req, res);
+    if (!username) {
+        return;
+    }
+    const parsed = parseSupportSettingsPayload(req.body);
+    if (!parsed) {
+        res.status(400).send(
+            "beneficiary_percent and curation_percent must be integers between 0 and 100"
+        );
+        return;
+    }
+    const { beneficiary_percent, curation_percent } = parsed;
+    pipe(
+        apiRequest(`support-settings/${username}`, "PUT", {}, {
+            username,
+            beneficiary_percent,
+            curation_percent
+        }),
+        res
+    );
+};
+
 export const schedules = async (req: express.Request, res: express.Response) => {
     const username = await validateCode(req);
     if (!username) {

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -113,6 +113,8 @@ server
     .post("^/private-api/bookmarks$", privateApi.bookmarks)
     .post("^/private-api/bookmarks-add$", privateApi.bookmarksAdd)
     .post("^/private-api/bookmarks-delete$", privateApi.bookmarksDelete)
+    .post("^/private-api/support-settings$", privateApi.supportSettings)
+    .post("^/private-api/support-settings-update$", privateApi.supportSettingsUpdate)
     .post("^/private-api/schedules$", privateApi.schedules)
     .post("^/private-api/schedules-add$", privateApi.schedulesAdd)
     .post("^/private-api/schedules-delete$", privateApi.schedulesDelete)


### PR DESCRIPTION
- Adds POST /private-api/support-settings and /private-api/support-settings-update, forwarding to the backend support-settings resource for the authenticated user.
- Username is resolved from the validated code only, matching the streak-freeze handlers; the body can never override it.
- Update payload is validated by an exported pure helper (both fields must be integers 0..100) with unit tests covering valid, boundary, out of range, float, string, boolean and missing cases.
- Maps axios to its CJS build in the jest config so the existing test suite can load again under jest 26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support settings endpoints so signed-in users can view and update their beneficiary and curation percentages.

* **Bug Fixes**
  * Improved validation for percentage values, rejecting invalid, missing, or out-of-range inputs to prevent bad updates.

* **Tests**
  * Expanded automated coverage for percentage parsing and existing request-header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->