### PR TITLE
CI: include the alpha origin in the vapi deploy matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region: [EU, US]
+        # ALPHA is the staging origin; it runs the same vision_vapi service and
+        # tracks main so staging cannot drift behind production again.
+        region: [EU, US, ALPHA]
     steps:
       - name: Deploy vision_vapi (${{ matrix.region }})
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
- Adds ALPHA to the deploy matrix so the staging origin tracks main like EU and US; host comes from the new SSH_HOST_ALPHA secret, all other connection secrets are shared.
- Prevents staging from drifting behind production (alpha was running a months-old image until refreshed manually).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded deployment coverage to include an additional staging region, improving rollout availability for users in that environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->