### PR TITLE
Drop the per-lookup price debug log

### DIFF
--- a/dotnet/EcencyApi/Handlers/WalletApi.Market.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Market.cs
@@ -459,14 +459,6 @@ public static partial class WalletApi
 
         if (tokenKey == currencyKey) return 1.0;
 
-        if (currencyKey != "usd")
-        {
-            var tokenData = JsVal.Prop(marketData, tokenKey) ?? JsVal.Prop(marketData, upperToken);
-            var quotesNode = JsVal.Prop(tokenData, "quotes");
-            var availableQuotes = quotesNode is JsonObject qo ? string.Join(",", qo.Select(kv => kv.Key)) : "";
-            Console.WriteLine($"Looking for {tokenKey} price in {currencyKey}. Available quotes: {availableQuotes}");
-        }
-
         var containers = CollectContainers(marketData, 3);
         var candidates = new List<JsonNode?>();
         void AddCandidate(JsonNode? v) { if (v != null) candidates.Add(v); }


### PR DESCRIPTION
GetTokenPrice wrote a line to stdout for every non-USD price lookup — inherited from the Node implementation for behavioral parity and unaffected by the Warning log-level default (it bypassed the logger). With the Node build retired, it was the last hot-path log noise. Responses unchanged; 42 tests green.