### PR TITLE
Tolerate lone-surrogate escapes in JSON strings

### DIFF
--- a/dotnet/EcencyApi.Tests/JsValTests.cs
+++ b/dotnet/EcencyApi.Tests/JsValTests.cs
@@ -50,6 +50,27 @@ public class JsValTests
     }
 
     [Fact]
+    public void LoneSurrogates_ExtractAndSerializeLikeJs()
+    {
+        // JSON.parse accepts lone surrogate escapes (a JS string is arbitrary
+        // UTF-16); System.Text.Json throws InvalidOperationException when
+        // materializing such strings, which turned payloads the Node service
+        // handled fine into 500s. The lenient path must extract them, and
+        // Stringify must re-emit the escape like well-formed JSON.stringify.
+        var node = JsonNode.Parse("{\"app\":\"x\\ud83dy\"}")!;
+
+        var s = JsVal.AsString(node["app"]);
+        Assert.NotNull(s);
+        Assert.Equal(3, s!.Length);
+        Assert.Equal('\ud83d', s[1]);
+
+        Assert.Equal("{\"app\":\"x\\ud83dy\"}", JsJson.Stringify(node));
+
+        // ToJsString (template-literal coercion) must survive it too
+        Assert.Equal("x\ud83dy", JsVal.ToJsString(node["app"]));
+    }
+
+    [Fact]
     public void ToJsString_CoercesLikeJs()
     {
         Assert.Equal("null", JsVal.ToJsString(null));

--- a/dotnet/EcencyApi.Tests/fixtures/crypto-vectors.json
+++ b/dotnet/EcencyApi.Tests/fixtures/crypto-vectors.json
@@ -1471,6 +1471,11 @@
  ],
  "validateCodeRaw": [
   {
+   "tokenJson": "{\"signed_message\":{\"type\":\"code\",\"app\":\"x\\ud83dy\"},\"authors\":[\"mallory\"],\"timestamp\":1752300000,\"signatures\":[\"ab\"]}",
+   "rawMessage": "{\"signed_message\":{\"type\":\"code\",\"app\":\"x\\ud83dy\"},\"authors\":[\"mallory\"],\"timestamp\":1752300000}",
+   "digestHex": "6162f04277a85ad43b614e076d81a317ad873450ff71176ff4715ea0844b5e78"
+  },
+  {
    "tokenJson": "{\"signed_message\":{\"type\":\"code\",\"app\":\"ecency.app\"},\"authors\":[\"alice\"],\"timestamp\":1751900000,\"signatures\":[\"ab\"]}",
    "rawMessage": "{\"signed_message\":{\"type\":\"code\",\"app\":\"ecency.app\"},\"authors\":[\"alice\"],\"timestamp\":1751900000}",
    "digestHex": "5290d7673a06a74f856d8d142764739972d85430654b23fff2c5c301a2a718f5"

--- a/dotnet/EcencyApi/Handlers/AuthApi.cs
+++ b/dotnet/EcencyApi/Handlers/AuthApi.cs
@@ -60,7 +60,7 @@ public static class AuthApi
                 // Array.prototype.toString: elements joined with ",", null -> ""
                 return string.Join(",", arr.Select(e => e == null ? "" : JsToString(e)));
             case JsonValue v:
-                if (v.TryGetValue<string>(out var s)) return s;
+                if (JsVal.TryGetStringLenient(v, out var s)) return s;
                 if (v.TryGetValue<bool>(out var b)) return b ? "true" : "false";
                 return JsJson.Stringify(v);
             default:

--- a/dotnet/EcencyApi/Handlers/HiveExplorer.cs
+++ b/dotnet/EcencyApi/Handlers/HiveExplorer.cs
@@ -128,7 +128,7 @@ public static class HiveExplorer
             return 0d;
         }
 
-        if (val is not JsonValue jv || !jv.TryGetValue<string>(out var s))
+        if (val is not JsonValue jv || !JsVal.TryGetStringLenient(jv, out var s))
         {
             return 0d;
         }
@@ -166,7 +166,7 @@ public static class HiveExplorer
     // TypeError), which the outer catch rewrites to "Failed to get globalProps".
     private static double GetVestAmount(JsonNode? value)
     {
-        if (value is JsonValue jv && jv.TryGetValue<string>(out _))
+        if (value is JsonValue jv && JsVal.TryGetStringLenient(jv, out _))
         {
             return ParseToken(value);
         }
@@ -238,7 +238,7 @@ public static class HiveExplorer
                         {
                             return double.NaN; // "true"/"false" don't parse
                         }
-                        if (ev.TryGetValue<string>(out var es))
+                        if (JsVal.TryGetStringLenient(ev, out var es))
                         {
                             return JsNumberString(es);
                         }
@@ -252,7 +252,7 @@ public static class HiveExplorer
                 {
                     return b ? 1d : 0d;
                 }
-                if (value.TryGetValue<string>(out var str))
+                if (JsVal.TryGetStringLenient(value, out var str))
                 {
                     return JsNumberString(str);
                 }

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Accounts.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Accounts.cs
@@ -69,7 +69,7 @@ public static partial class PrivateApi
     private static async Task<bool> VerifyTurnstile(JsonNode? token, string ip)
     {
         var secret = Config.TurnstileSecret;
-        var tokenStr = token is JsonValue tv && tv.TryGetValue<string>(out string? ts) ? ts : null;
+        var tokenStr = token is JsonValue tv && JsVal.TryGetStringLenient(tv, out string? ts) ? ts : null;
         if (string.IsNullOrEmpty(secret) || tokenStr == null || tokenStr.Trim().Length == 0)
         {
             return false;

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Chain.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Chain.cs
@@ -259,7 +259,7 @@ public static partial class PrivateApi
 
     private static string ParseHexBalance(JsonNode? value)
     {
-        if (value is not JsonValue jsonValue || !jsonValue.TryGetValue<string>(out var text))
+        if (value is not JsonValue jsonValue || !JsVal.TryGetStringLenient(jsonValue, out var text))
         {
             throw new Exception("Invalid hexadecimal balance response");
         }
@@ -595,7 +595,7 @@ public static partial class PrivateApi
         var data = resp.BodyIsJson ? resp.Json : JsonValue.Create(resp.RawText);
         var obj = data as JsonObject;
 
-        var accessToken = obj?["access_token"] is JsonValue tokenValue && tokenValue.TryGetValue<string>(out var tokenText)
+        var accessToken = obj?["access_token"] is JsonValue tokenValue && JsVal.TryGetStringLenient(tokenValue, out var tokenText)
             ? tokenText
             : null;
 
@@ -1107,7 +1107,7 @@ public static partial class PrivateApi
         null => "null",
         JsonObject => "[object Object]",
         JsonArray arr => string.Join(",", arr.Select(ChainJsString)),
-        JsonValue v when v.TryGetValue<string>(out var s) => s,
+        JsonValue v when JsVal.TryGetStringLenient(v, out var s) => s,
         _ => JsJson.Stringify(node),
     };
 

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Core.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Core.cs
@@ -37,7 +37,7 @@ public static partial class PrivateApi
     {
         var hasCode = body.TryGetPropertyValue("code", out var codeNode);
         string? code = null;
-        if (codeNode is JsonValue codeValue && codeValue.TryGetValue<string>(out var codeStr))
+        if (codeNode is JsonValue codeValue && JsVal.TryGetStringLenient(codeValue, out var codeStr))
         {
             code = codeStr;
         }
@@ -98,7 +98,7 @@ public static partial class PrivateApi
 
             string? author = null;
             if (authors is { Count: > 0 } && authors[0] is JsonValue authorValue
-                && authorValue.TryGetValue<string>(out var authorStr))
+                && JsVal.TryGetStringLenient(authorValue, out var authorStr))
             {
                 author = authorStr;
             }
@@ -109,7 +109,7 @@ public static partial class PrivateApi
 
             string? signature = null;
             if (signatures is { Count: > 0 } && signatures[0] is JsonValue signatureValue
-                && signatureValue.TryGetValue<string>(out var signatureStr))
+                && JsVal.TryGetStringLenient(signatureValue, out var signatureStr))
             {
                 signature = signatureStr;
             }
@@ -210,7 +210,7 @@ public static partial class PrivateApi
             }
 
             var first = item[0]; // throws for non-indexable nodes, like JS destructuring a non-iterable
-            keys.Add(first is JsonValue v && v.TryGetValue<string>(out var key) ? key : null);
+            keys.Add(first is JsonValue v && JsVal.TryGetStringLenient(v, out var key) ? key : null);
         }
 
         return keys;

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Feeds.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Feeds.cs
@@ -297,7 +297,7 @@ public static partial class PrivateApi
                     JsonObject => "[object Object]",
                     _ => FeedsJsToString(e),
                 }));
-            case JsonValue v when v.TryGetValue<string>(out var s):
+            case JsonValue v when JsVal.TryGetStringLenient(v, out var s):
                 return s;
             case JsonValue v when v.TryGetValue<bool>(out var b):
                 return b ? "true" : "false";

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
@@ -27,7 +27,7 @@ public static partial class PrivateApi
         }
         if (node is JsonValue v)
         {
-            if (v.TryGetValue<string>(out var s))
+            if (JsVal.TryGetStringLenient(v, out var s))
             {
                 return s;
             }

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Payments.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Payments.cs
@@ -148,7 +148,7 @@ public static partial class PrivateApi
         // Reject a malformed value at this boundary before forwarding (typeof guard first:
         // a non-string must never be coerced by the regex test and forwarded).
         var hostingTargetPresent = body.TryGetPropertyValue("hosting_target", out var hostingTargetNode);
-        var hostingTarget = hostingTargetNode is JsonValue htv && htv.TryGetValue<string>(out var hts)
+        var hostingTarget = hostingTargetNode is JsonValue htv && JsVal.TryGetStringLenient(htv, out var hts)
             ? hts
             : null;
         if (hostingTargetPresent && (hostingTarget == null || !PaymentsHiveNameRegex.IsMatch(hostingTarget)))
@@ -160,7 +160,7 @@ public static partial class PrivateApi
         // lowercase, so normalize typed input (trim + lowercase) before validating so a
         // recipient like "Alice" is accepted as "alice", and forward the canonical form.
         var giftRecipientPresent = body.TryGetPropertyValue("gift_recipient", out var giftRecipientNode);
-        var giftRecipient = giftRecipientNode is JsonValue grv && grv.TryGetValue<string>(out var grs)
+        var giftRecipient = giftRecipientNode is JsonValue grv && JsVal.TryGetStringLenient(grv, out var grs)
             ? grs.Trim().ToLowerInvariant()
             : null;
         if (giftRecipientPresent && (giftRecipient == null || !PaymentsHiveNameRegex.IsMatch(giftRecipient)))
@@ -169,7 +169,7 @@ public static partial class PrivateApi
             return;
         }
         var giftMessagePresent = body.TryGetPropertyValue("gift_message", out var giftMessageNode);
-        var giftMessage = giftMessageNode is JsonValue gmv && gmv.TryGetValue<string>(out var gms)
+        var giftMessage = giftMessageNode is JsonValue gmv && JsVal.TryGetStringLenient(gmv, out var gms)
             ? gms
             : null;
         if (giftMessagePresent && (giftMessage == null || giftMessage.Length > 200))
@@ -392,7 +392,7 @@ public static partial class PrivateApi
     private static async Task<bool> PaymentsVerifyTurnstile(JsonNode? token, string ip)
     {
         var secret = Config.TurnstileSecret;
-        var tokenStr = token is JsonValue tv && tv.TryGetValue<string>(out var ts) ? ts : null;
+        var tokenStr = token is JsonValue tv && JsVal.TryGetStringLenient(tv, out var ts) ? ts : null;
         if (string.IsNullOrEmpty(secret) || tokenStr == null || tokenStr.Trim().Length == 0)
         {
             return false;
@@ -474,7 +474,7 @@ public static partial class PrivateApi
             case JsonObject:
                 return "[object Object]";
             case JsonValue value:
-                if (value.TryGetValue<string>(out var s))
+                if (JsVal.TryGetStringLenient(value, out var s))
                 {
                     return s;
                 }

--- a/dotnet/EcencyApi/Handlers/PrivateApi.UserData1.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.UserData1.cs
@@ -405,7 +405,7 @@ file static class UserData1Helpers
                 // Array.prototype.toString: elements joined by ",", holes/null -> ""
                 return string.Join(",", arr.Select(item => item == null ? "" : Template(item)));
             default:
-                if (node is JsonValue jv && jv.TryGetValue<string>(out var s))
+                if (node is JsonValue jv && JsVal.TryGetStringLenient(jv, out var s))
                 {
                     return s;
                 }

--- a/dotnet/EcencyApi/Handlers/PrivateApi.UserData2.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.UserData2.cs
@@ -328,7 +328,7 @@ file static class UserData2Js
                 // Array.prototype.toString: join(","), null/undefined elements -> ""
                 return string.Join(",", arr.Select(el => el == null ? "" : JsString(el)));
             case JsonValue v:
-                if (v.TryGetValue<string>(out var s)) return s;
+                if (JsVal.TryGetStringLenient(v, out var s)) return s;
                 if (v.TryGetValue<bool>(out var b)) return b ? "true" : "false";
                 // numbers: String(n) == JSON.stringify(n) for finite doubles
                 return JsJson.Stringify(node);

--- a/dotnet/EcencyApi/Handlers/SearchApi.cs
+++ b/dotnet/EcencyApi/Handlers/SearchApi.cs
@@ -54,7 +54,7 @@ public static class SearchApi
                 // Array.prototype.toString: elements joined with ",", null -> ""
                 return string.Join(",", arr.Select(e => e == null ? "" : JsToString(e)));
             case JsonValue v:
-                if (v.TryGetValue<string>(out var s)) return s;
+                if (JsVal.TryGetStringLenient(v, out var s)) return s;
                 if (v.TryGetValue<bool>(out var b)) return b ? "true" : "false";
                 return JsJson.Stringify(v);
             default:

--- a/dotnet/EcencyApi/Infrastructure/ApiClient.cs
+++ b/dotnet/EcencyApi/Infrastructure/ApiClient.cs
@@ -43,7 +43,7 @@ public static class ApiClient
             {
                 headers[kv.Key] = kv.Value switch
                 {
-                    JsonValue v when v.TryGetValue<string>(out var s) => s,
+                    JsonValue v when JsVal.TryGetStringLenient(v, out var s) => s,
                     null => "null",
                     _ => kv.Value.ToJsonString(),
                 };

--- a/dotnet/EcencyApi/Infrastructure/HttpContextExtensions.cs
+++ b/dotnet/EcencyApi/Infrastructure/HttpContextExtensions.cs
@@ -92,7 +92,7 @@ public static class HttpContextExtensions
 
     /// <summary>Convenience: string body field (undefined -> null).</summary>
     public static string? Str(this JsonObject body, string key) =>
-        body.TryGetPropertyValue(key, out var v) && v is JsonValue val && val.TryGetValue<string>(out var s)
+        body.TryGetPropertyValue(key, out var v) && v is JsonValue val && JsVal.TryGetStringLenient(val, out var s)
             ? s
             : null;
 

--- a/dotnet/EcencyApi/Infrastructure/JsJson.cs
+++ b/dotnet/EcencyApi/Infrastructure/JsJson.cs
@@ -63,7 +63,7 @@ public static class JsJson
 
     private static void WritePrimitive(StringBuilder sb, JsonValue value)
     {
-        if (value.TryGetValue<string>(out var s))
+        if (JsVal.TryGetStringLenient(value, out var s))
         {
             WriteString(sb, s);
             return;
@@ -260,7 +260,7 @@ public static class JsJson
             case JsonArray:
                 return true;
             case JsonValue v:
-                if (v.TryGetValue<string>(out var s)) return s.Length > 0;
+                if (JsVal.TryGetStringLenient(v, out var s)) return s.Length > 0;
                 if (v.TryGetValue<bool>(out var b)) return b;
                 // Parsed values are element-backed; programmatically built ones
                 // are CLR-backed and would throw on GetValue<JsonElement>().

--- a/dotnet/EcencyApi/Infrastructure/JsVal.cs
+++ b/dotnet/EcencyApi/Infrastructure/JsVal.cs
@@ -19,7 +19,7 @@ public static class JsVal
     public static bool IsString(JsonNode? n) =>
         n is JsonValue v && v.TryGetValue<JsonElement>(out var e)
             ? e.ValueKind == JsonValueKind.String
-            : n is JsonValue v2 && v2.TryGetValue<string>(out _);
+            : n is JsonValue v2 && JsVal.TryGetStringLenient(v2, out _);
 
     public static bool IsNumber(JsonNode? n)
     {
@@ -41,12 +41,77 @@ public static class JsVal
 
     // ---- accessors -------------------------------------------------------
 
+    /// <summary>
+    /// String extraction tolerant of lone-surrogate \u escapes. JavaScript's
+    /// JSON.parse accepts them (JS strings are arbitrary UTF-16), but
+    /// System.Text.Json throws InvalidOperationException when materializing
+    /// such strings — which turned payloads the Node service handled fine into
+    /// 500s. Falls back to manually unescaping the raw JSON text with JS
+    /// semantics (\uXXXX decodes to the code unit, paired or not).
+    /// </summary>
+    public static bool TryGetStringLenient(JsonValue v, out string value)
+    {
+        try
+        {
+            if (v.TryGetValue<string>(out value!))
+            {
+                return true;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // incomplete surrogate pair in the JSON text; fall through
+        }
+
+        if (v.TryGetValue<JsonElement>(out var el) && el.ValueKind == JsonValueKind.String)
+        {
+            value = UnescapeJsonStringLenient(el.GetRawText());
+            return true;
+        }
+
+        value = null!;
+        return false;
+    }
+
+    /// <summary>Unescape a raw JSON string literal (including quotes) with JS semantics.</summary>
+    internal static string UnescapeJsonStringLenient(string raw)
+    {
+        var sb = new StringBuilder(raw.Length);
+        for (var i = 1; i < raw.Length - 1; i++)
+        {
+            var c = raw[i];
+            if (c != '\\')
+            {
+                sb.Append(c);
+                continue;
+            }
+            i++;
+            switch (raw[i])
+            {
+                case '"': sb.Append('"'); break;
+                case '\\': sb.Append('\\'); break;
+                case '/': sb.Append('/'); break;
+                case 'b': sb.Append('\b'); break;
+                case 'f': sb.Append('\f'); break;
+                case 'n': sb.Append('\n'); break;
+                case 'r': sb.Append('\r'); break;
+                case 't': sb.Append('\t'); break;
+                case 'u':
+                    sb.Append((char)ushort.Parse(raw.AsSpan(i + 1, 4),
+                        NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+                    i += 4;
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
     /// <summary>The JSON string value, or null when the node is not a string.</summary>
     public static string? AsString(JsonNode? n)
     {
         if (n is JsonValue v)
         {
-            if (v.TryGetValue<string>(out var s)) return s;
+            if (JsVal.TryGetStringLenient(v, out var s)) return s;
             if (v.TryGetValue<JsonElement>(out var e) && e.ValueKind == JsonValueKind.String)
                 return e.GetString();
         }
@@ -180,7 +245,7 @@ public static class JsVal
             case JsonObject:
                 return "[object Object]";
             case JsonValue v:
-                if (v.TryGetValue<string>(out var s)) return s;
+                if (JsVal.TryGetStringLenient(v, out var s)) return s;
                 if (v.TryGetValue<bool>(out var b)) return b ? "true" : "false";
                 var num = AsNumber(n);
                 if (num.HasValue) return JsNumberToString(num.Value);

--- a/dotnet/EcencyApi/Infrastructure/Upstream.cs
+++ b/dotnet/EcencyApi/Infrastructure/Upstream.cs
@@ -203,7 +203,7 @@ public static class Upstream
         }
         catch (UpstreamTimeoutException e)
         {
-            Console.Error.WriteLine($"pipe(): upstream timeout: {e.Message}");
+            Console.Error.WriteLine($"pipe(): upstream timeout on {ctx.Request.Path}: {e.Message}");
             if (!ctx.Response.HasStarted)
             {
                 ctx.Response.StatusCode = 504;
@@ -213,7 +213,7 @@ public static class Upstream
         }
         catch (Exception e)
         {
-            Console.Error.WriteLine($"pipe(): error while processing API call: {e.Message}");
+            Console.Error.WriteLine($"pipe(): error on {ctx.Request.Path}: {e.Message}");
             if (!ctx.Response.HasStarted)
             {
                 ctx.Response.StatusCode = 500;
@@ -224,7 +224,7 @@ public static class Upstream
 
         if (ctx.Response.HasStarted)
         {
-            Console.Error.WriteLine("pipe(): headers already sent, skipping response");
+            Console.Error.WriteLine($"pipe(): headers already sent, skipping response ({ctx.Request.Path})");
             return;
         }
 
@@ -266,7 +266,8 @@ public static class Upstream
                 case JsonValueKind.String:
                     // res.send("str") sends the raw string as text/html
                     ctx.Response.ContentType = "text/html; charset=utf-8";
-                    await ctx.Response.WriteAsync(value.GetValue<string>());
+                    JsVal.TryGetStringLenient(value, out var bodyStr);
+                    await ctx.Response.WriteAsync(bodyStr);
                     return;
             }
         }

--- a/dotnet/EcencyApi/Infrastructure/Upstream.cs
+++ b/dotnet/EcencyApi/Infrastructure/Upstream.cs
@@ -266,8 +266,10 @@ public static class Upstream
                 case JsonValueKind.String:
                     // res.send("str") sends the raw string as text/html
                     ctx.Response.ContentType = "text/html; charset=utf-8";
-                    JsVal.TryGetStringLenient(value, out var bodyStr);
-                    await ctx.Response.WriteAsync(bodyStr);
+                    if (JsVal.TryGetStringLenient(value, out var bodyStr))
+                    {
+                        await ctx.Response.WriteAsync(bodyStr);
+                    }
                     return;
             }
         }

--- a/dotnet/tools/gen-vectors.js
+++ b/dotnet/tools/gen-vectors.js
@@ -97,6 +97,9 @@ for (const [l, app, timestamp] of [
 // b64u-encode it) -> the exact rawMessage Node re-serializes and hashes.
 // Exercises nested key-order preservation, fractional timestamps, unicode.
 const tokenJsons = [
+    // lone surrogate escape: JSON.parse accepts it; the port must too (and
+    // re-serialize it as the same escape, per well-formed JSON.stringify)
+    '{"signed_message":{"type":"code","app":"x\\ud83dy"},"authors":["mallory"],"timestamp":1752300000,"signatures":["ab"]}',
     '{"signed_message":{"type":"code","app":"ecency.app"},"authors":["alice"],"timestamp":1751900000,"signatures":["ab"]}',
     '{"signed_message":{"app":"ecency.app","type":"code"},"authors":["bob.tester"],"timestamp":1751900000.123,"signatures":["cd"]}',
     '{"timestamp":1700000000.5,"signatures":["ef"],"signed_message":{"type":"login","app":"éçency 漢字"},"authors":["carol-x1"]}',


### PR DESCRIPTION
Day-after production monitoring caught dozens of unhandled `InvalidOperationException: Cannot read incomplete UTF-16 JSON text as string with missing low surrogate` per day. Root cause: JavaScript's `JSON.parse` accepts lone surrogate escapes (JS strings are arbitrary UTF-16), but System.Text.Json throws when materializing such strings — so requests the Node service handled fine (typically bot traffic with malformed unicode) were returning 500.

- All string extraction now routes through `JsVal.TryGetStringLenient`, which falls back to unescaping the raw JSON text with JS semantics (`\uXXXX` decodes to the code unit, paired or not).
- `JsJson.Stringify` already re-emits lone surrogates as escapes (well-formed `JSON.stringify` mode), so the signature-hashing path stays byte-exact — proven by a new V8-generated golden vector that runs through the full validateCode re-serialization parity test.
- `pipe()` diagnostics now include the request path, making the headers-already-sent warnings attributable to specific endpoints.

Verified: 43 tests green; live smoke with lone-surrogate payloads returns the same statuses Node did (401 invalid-token / 200 token-create) with zero unhandled exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with JavaScript-style JSON string handling, including escaped and lone-surrogate characters.
  * Updated request, response, authentication, payment, search, and token-processing flows to handle loosely typed JSON string values more reliably.
  * Improved serialization and string coercion for JSON values.

* **Tests**
  * Added coverage for lone-surrogate extraction, coercion, serialization, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->