### PR TITLE
Stop forwarding rate-limited checkin activities upstream

### DIFF
--- a/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
@@ -107,13 +107,12 @@ public static partial class PrivateApi
             if (!string.IsNullOrEmpty(rec))
             {
                 var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-                if (double.TryParse(rec, System.Globalization.NumberStyles.Float,
+                var withinWindow = double.TryParse(rec, System.Globalization.NumberStyles.Float,
                         System.Globalization.CultureInfo.InvariantCulture, out var recMs)
-                    && nowMs - recMs < 900000)
+                    && nowMs - recMs < 900000;
+
+                if (withinWindow)
                 {
-                    // Node sends 201 here WITHOUT returning; the cache write and the
-                    // upstream usr-activity call below still run (pipe then skips the
-                    // second response) — replicated as-is.
                     await ctx.SendJson(201, new JsonObject());
                 }
                 try
@@ -125,6 +124,15 @@ public static partial class PrivateApi
                 {
                     Console.Error.WriteLine(e);
                     Console.Error.WriteLine("Cache set failed.");
+                }
+                if (withinWindow)
+                {
+                    // The Node implementation was missing this return: it acked the
+                    // rate-limited checkin with 201 but still forwarded the duplicate
+                    // event upstream (pipe then skipped the second response, logging
+                    // "headers already sent" on every occurrence). Short-circuit after
+                    // refreshing the sliding window, as the branch always intended.
+                    return;
                 }
             }
             else


### PR DESCRIPTION
The `ty === 10` rate-limit branch in the activities handler acks repeat visits (same IP within 15 minutes) with an early 201, but was missing a `return` — a bug inherited from the Node implementation. The duplicate checkin event was therefore still POSTed to the private API on every rate-limited hit, defeating the branch's purpose, and `pipe()` logged `headers already sent` each time (path-attributed diagnostics from #52 show this is the *only* source of that warning in production, thousands of occurrences per day).

The fix short-circuits after sending the 201 and refreshing the sliding cache window, exactly as the branch always intended. First-seen requests and requests outside the 15-minute window are unchanged and still forward upstream. Deliberate behavior change: upstream stops receiving the duplicate events (which its own per-activity accounting rules should already have been discarding).