### PR TITLE
Treat empty Hive-Engine rewards response as no rewards, not an error

### DIFF
--- a/dotnet/EcencyApi/Handlers/WalletApi.Engine.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Engine.cs
@@ -180,12 +180,15 @@ public static partial class WalletApi
             var response = await EngineRewardsRequest(username,
                 new[] { new KeyValuePair<string, string?>("hive", "1") });
 
-            // An account with no Hive-Engine activity is the common case, not a failure:
-            // the upstream answers with an empty object, which falls through the loop
-            // below to an empty result. Previously both that and a non-object response
-            // threw into the catch, logging an error on every such request.
-            if (response.Json is not JsonObject obj) return new JsonArray();
+            // A non-object body (unparseable, or valid JSON that isn't an object) means a
+            // degraded upstream: keep throwing so the catch below logs it.
+            if (response.Json is not JsonObject obj)
+                throw new Exception("Unexpected rewards payload");
 
+            // An empty object is NOT a failure — it is what the upstream returns for an
+            // account with no Hive-Engine activity, which is the common case. It falls
+            // through the loop below to the same empty result the catch used to produce,
+            // minus an error log on every such request.
             var filtered = new JsonArray();
             foreach (var raw in obj.Select(kv => kv.Value))
             {

--- a/dotnet/EcencyApi/Handlers/WalletApi.Engine.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Engine.cs
@@ -180,14 +180,14 @@ public static partial class WalletApi
             var response = await EngineRewardsRequest(username,
                 new[] { new KeyValuePair<string, string?>("hive", "1") });
 
-            if (response.Json is not JsonObject obj)
-                throw new Exception("No rewards data returned");
-
-            var rawValues = obj.Select(kv => kv.Value).ToList();
-            if (rawValues.Count == 0) throw new Exception("No rewards data returned");
+            // An account with no Hive-Engine activity is the common case, not a failure:
+            // the upstream answers with an empty object, which falls through the loop
+            // below to an empty result. Previously both that and a non-object response
+            // threw into the catch, logging an error on every such request.
+            if (response.Json is not JsonObject obj) return new JsonArray();
 
             var filtered = new JsonArray();
-            foreach (var raw in rawValues)
+            foreach (var raw in obj.Select(kv => kv.Value))
             {
                 var converted = HiveEngine.ConvertRewardsStatus(raw);
                 var pendingToken = JsVal.AsNumber(converted["pendingToken"]);


### PR DESCRIPTION
`FetchEngineRewards` treated "this account has no Hive-Engine rewards" as a failure.

The rewards upstream answers with an empty object for an account with no Hive-Engine activity. The handler threw on that (and on a non-object response), fell into the catch, logged `failed to get unclaimed engine rewards No rewards data returned`, and returned an empty array. The empty array was the right answer — but it was reached via an exception and an error log, on every request for such an account. That is a hot-path write on the portfolio endpoints, against invariant 6.

This returns the empty result directly. An empty object now falls through the existing loop to an empty array, which is what the catch produced anyway.

Not a behavior change:

- non-object response: was throw -> catch -> empty array. Now: empty array.
- empty object: was throw -> catch -> empty array. Now: loop over zero entries -> empty array.
- non-empty object: unchanged.
- a genuine failure (network, malformed payload) still reaches the catch and is still logged.

Verified by running this build and `main` side by side against the same upstreams and diffing `/wallet-api/portfolio-v2`: responses are byte-identical for accounts with no engine rewards, and the error log goes from one line per request to none. Accounts that do have rewards are byte-identical too, apart from live chain values (HP balance, APR, staked token accrual) that move between calls. Test suite green.
