### PR TITLE
Portfolio legs degrade per-fetch instead of losing whole layers

### DIFF
--- a/dotnet/EcencyApi/Handlers/WalletApi.Engine.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Engine.cs
@@ -165,7 +165,11 @@ public static partial class WalletApi
 
             var tokensTask = FetchEngineTokens(symbols);
             var metricsTask = FetchEngineMetrics(symbols);
-            var unclaimedTask = FetchEngineRewards(username);
+            // The rewards upstream allows 30s, but this whole fetch must fit
+            // the portfolioV2 engine leg budget (4.5s) — a slow rewards call
+            // would otherwise blank the entire engine layer. Rewards are
+            // decoration (pendingToken badges); degrade to none instead.
+            var unclaimedTask = WithTimeout(FetchEngineRewards(username), EngineRewardsTimeoutMs, new JsonArray());
             await Task.WhenAll(tokensTask, metricsTask, unclaimedTask);
             var tokens = tokensTask.Result;
             var metrics = metricsTask.Result;
@@ -295,6 +299,7 @@ public static partial class WalletApi
 
     private const int FastLegTimeout = 3000;
     private const int SlowLegTimeout = 4500;
+    private const int EngineRewardsTimeoutMs = 2000;
 
     private static async Task<T> WithTimeout<T>(Task<T> task, int ms, T fallback)
     {

--- a/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
@@ -670,15 +670,17 @@ public static partial class WalletApi
     private const int ChainBalanceTimeoutMs = 2000;
     private const int ChainFetchConcurrency = 8;
     // Hard bound so the worst case is exactly two waves (4s < 4.5s leg) no
-    // matter how many addresses a profile lists. A profile with more entries
-    // keeps its first 16 wallets instead of risking the whole layer.
+    // matter how many addresses a profile lists. Wallets past the cap are not
+    // fetched but still appear as error items, so the response acknowledges
+    // every configured wallet instead of silently omitting the tail.
     private const int MaxChainWallets = 16;
 
     internal static async Task<List<JsonObject>> BuildChainLayer(JsonNode? accountData, JsonNode? marketData, string currency, bool? onlyEnabled)
     {
         var wallets = ExtractExternalWallets(accountData, onlyEnabled == true);
         if (wallets.Count == 0) return new List<JsonObject>();
-        if (wallets.Count > MaxChainWallets) wallets = wallets.Take(MaxChainWallets).ToList();
+        var skipped = wallets.Skip(MaxChainWallets).ToList();
+        if (skipped.Count > 0) wallets = wallets.Take(MaxChainWallets).ToList();
 
         var items = await ProcessWithConcurrencyLimit(wallets, async wallet =>
         {
@@ -716,7 +718,21 @@ public static partial class WalletApi
             }
         }, ChainFetchConcurrency);
 
-        return items.Where(x => x != null).ToList();
+        var result = items.Where(x => x != null).ToList();
+        foreach (var wallet in skipped)
+        {
+            var chain = wallet.Chain.ToLowerInvariant();
+            var config = ChainConfigs[chain];
+            var decimals = (int)(wallet.Decimals ?? config.Decimals);
+            var price = GetTokenPrice(marketData, wallet.Symbol, currency);
+            result.Add(MakePortfolioItem(
+                !string.IsNullOrEmpty(wallet.Name) ? wallet.Name : config.Name,
+                !string.IsNullOrEmpty(wallet.Symbol) ? wallet.Symbol : config.Symbol,
+                "chain", 0, price, currency, decimals,
+                new ItemOptions { Address = wallet.Address, Error = "Wallet limit reached" },
+                config.IconUrl ?? Constants.AssetIconUrls["CHAIN_PLACEHOLDER"], ChainActions()));
+        }
+        return result;
     }
 
     // ---- JS numeric string formatting ------------------------------------

--- a/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
@@ -663,10 +663,12 @@ public static partial class WalletApi
     // attempt, but the portfolioV2 chain leg has a 4.5s budget for the WHOLE
     // layer — without a per-wallet cap, one cold/slow provider blows the leg
     // timeout and the entire chain layer silently disappears from the response
-    // (observed intermittently in production). 2s keeps two concurrency
-    // batches inside the leg budget; the capped wallet degrades to an error
-    // item instead of sinking its siblings.
+    // (observed intermittently in production). The capped wallet degrades to
+    // an error item instead of sinking its siblings. The concurrency width
+    // must keep ceil(n / width) * cap under the leg budget: at width 8, up to
+    // 16 wallets (2 batches) finish worst-case in 4s.
     private const int ChainBalanceTimeoutMs = 2000;
+    private const int ChainFetchConcurrency = 8;
 
     internal static async Task<List<JsonObject>> BuildChainLayer(JsonNode? accountData, JsonNode? marketData, string currency, bool? onlyEnabled)
     {
@@ -707,7 +709,7 @@ public static partial class WalletApi
                     new ItemOptions { Address = wallet.Address, Error = errorMessage },
                     config.IconUrl ?? Constants.AssetIconUrls["CHAIN_PLACEHOLDER"], ChainActions());
             }
-        }, 3);
+        }, ChainFetchConcurrency);
 
         return items.Where(x => x != null).ToList();
     }

--- a/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
@@ -669,11 +669,16 @@ public static partial class WalletApi
     // 16 wallets (2 batches) finish worst-case in 4s.
     private const int ChainBalanceTimeoutMs = 2000;
     private const int ChainFetchConcurrency = 8;
+    // Hard bound so the worst case is exactly two waves (4s < 4.5s leg) no
+    // matter how many addresses a profile lists. A profile with more entries
+    // keeps its first 16 wallets instead of risking the whole layer.
+    private const int MaxChainWallets = 16;
 
     internal static async Task<List<JsonObject>> BuildChainLayer(JsonNode? accountData, JsonNode? marketData, string currency, bool? onlyEnabled)
     {
         var wallets = ExtractExternalWallets(accountData, onlyEnabled == true);
         if (wallets.Count == 0) return new List<JsonObject>();
+        if (wallets.Count > MaxChainWallets) wallets = wallets.Take(MaxChainWallets).ToList();
 
         var items = await ProcessWithConcurrencyLimit(wallets, async wallet =>
         {

--- a/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Layers.cs
@@ -659,6 +659,15 @@ public static partial class WalletApi
         return results.ToList();
     }
 
+    // Per-wallet cap on the balance fetch. The chain providers allow 10s per
+    // attempt, but the portfolioV2 chain leg has a 4.5s budget for the WHOLE
+    // layer — without a per-wallet cap, one cold/slow provider blows the leg
+    // timeout and the entire chain layer silently disappears from the response
+    // (observed intermittently in production). 2s keeps two concurrency
+    // batches inside the leg budget; the capped wallet degrades to an error
+    // item instead of sinking its siblings.
+    private const int ChainBalanceTimeoutMs = 2000;
+
     internal static async Task<List<JsonObject>> BuildChainLayer(JsonNode? accountData, JsonNode? marketData, string currency, bool? onlyEnabled)
     {
         var wallets = ExtractExternalWallets(accountData, onlyEnabled == true);
@@ -672,7 +681,10 @@ public static partial class WalletApi
 
             try
             {
-                var data = await PrivateApi.FetchChainBalance(chain, wallet.Address);
+                var fetchTask = PrivateApi.FetchChainBalance(chain, wallet.Address);
+                var completed = await Task.WhenAny(fetchTask, Task.Delay(ChainBalanceTimeoutMs));
+                if (completed != fetchTask) throw new Exception("Chain balance request timed out");
+                var data = await fetchTask;
                 var balance = ConvertChainBalanceToAmount(data, decimals);
                 var price = GetTokenPrice(marketData, wallet.Symbol, currency);
                 var iconUrl = config.IconUrl ?? Constants.AssetIconUrls["CHAIN_PLACEHOLDER"];


### PR DESCRIPTION
Users intermittently saw external chain balances (and occasionally engine tokens) missing from portfolioV2 responses. The layers are computed under a fail-fast leg timeout, but the fetches inside had far larger budgets: chain balance providers allow 10s per attempt and the unclaimed-rewards upstream 30s. One cold or slow provider pushed the whole leg past its budget and the entire layer silently disappeared — while every individual balance probe answered in well under a second (the balance cache is short, so portfolio requests routinely hit cold providers).

## Changes

- **Chain layer**: each wallet's balance fetch is capped at 2s inside `BuildChainLayer`. A capped wallet degrades to an error item (same as an upstream failure today) instead of sinking every other wallet; two concurrency batches still fit inside the leg budget.
- **Engine layer**: the unclaimed-rewards fetch inside `FetchEngineTokensWithBalance` is capped at 2s and degrades to no pending-reward badges. Token balances, metadata, and prices are unaffected — rewards are decoration and shouldn't be able to blank the token list.

No route/response shape changes; both caps reuse the existing degrade paths.

## Testing

- Full suite passes (55).
- Local run against real upstreams: 10/10 consecutive portfolioV2 calls for a wallet-heavy account returned the complete chain layer (previously intermittent), with engine and hive layers unchanged.