### PR TITLE
feat(wallet): expose set_withdraw_vesting_route in the HP action list

### DIFF
--- a/dotnet/EcencyApi.Tests/WalletActionsTests.cs
+++ b/dotnet/EcencyApi.Tests/WalletActionsTests.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Nodes;
+using EcencyApi.Handlers;
+using Xunit;
+
+namespace EcencyApi.Tests;
+
+/// <summary>
+/// The token action ids are a client-facing contract: web and mobile map them to
+/// concrete wallet operations, and an id neither client recognizes either renders
+/// nothing (web drops unknown ids) or renders an unlabeled control (mobile passes
+/// them through). Pin the ids and their order.
+/// </summary>
+public class WalletActionsTests
+{
+    private static string[] Ids(JsonArray actions) =>
+        actions.Select(a => a!["id"]!.GetValue<string>()).ToArray();
+
+    [Fact]
+    public void HpActions_AreTheChainOperationNamesInRenderOrder()
+    {
+        Assert.Equal(
+            new[] { "delegate_vesting_shares", "withdraw_vesting", "set_withdraw_vesting_route" },
+            Ids(WalletApi.HpActions()));
+    }
+
+    [Fact]
+    public void HiveActions_OnlyOfferSavingsWithdrawalWhenSavingsExist()
+    {
+        Assert.DoesNotContain("transfer_from_savings", Ids(WalletApi.BuildHiveActions(0)));
+        Assert.Contains("transfer_from_savings", Ids(WalletApi.BuildHiveActions(1.5)));
+    }
+
+    [Fact]
+    public void HbdActions_OnlyOfferSavingsWithdrawalWhenSavingsExist()
+    {
+        Assert.DoesNotContain("transfer_from_savings", Ids(WalletApi.BuildHbdActions(0)));
+        Assert.Contains("transfer_from_savings", Ids(WalletApi.BuildHbdActions(1.5)));
+    }
+}

--- a/dotnet/EcencyApi/Handlers/WalletApi.Market.cs
+++ b/dotnet/EcencyApi/Handlers/WalletApi.Market.cs
@@ -32,7 +32,10 @@ public static partial class WalletApi
         return Actions(ids.ToArray());
     }
 
-    internal static JsonArray HpActions() => Actions("delegate_vesting_shares", "withdraw_vesting");
+    // set_withdraw_vesting_route lets clients link straight to the withdraw routes UI.
+    // Deliberately added after the original two ids: clients render actions in order.
+    internal static JsonArray HpActions() =>
+        Actions("delegate_vesting_shares", "withdraw_vesting", "set_withdraw_vesting_route");
 
     internal static JsonArray BuildHbdActions(double savings)
     {

--- a/dotnet/parity/driver.py
+++ b/dotnet/parity/driver.py
@@ -228,6 +228,10 @@ KNOWN_DIVERGENCES = {
         "Same request-delete rerouting as ::min.",
     "/private-api/request-delete::badcode":
         "Same request-delete rerouting as ::min.",
+    "/wallet-api/portfolio-v2::pop":
+        "The HP action list gained set_withdraw_vesting_route so clients can link "
+        "straight to the withdraw routes UI; the reference build emits only "
+        "delegate_vesting_shares and withdraw_vesting.",
 }
 
 

--- a/dotnet/parity/driver.py
+++ b/dotnet/parity/driver.py
@@ -228,11 +228,16 @@ KNOWN_DIVERGENCES = {
         "Same request-delete rerouting as ::min.",
     "/private-api/request-delete::badcode":
         "Same request-delete rerouting as ::min.",
-    "/wallet-api/portfolio-v2::pop":
-        "The HP action list gained set_withdraw_vesting_route so clients can link "
-        "straight to the withdraw routes UI; the reference build emits only "
-        "delegate_vesting_shares and withdraw_vesting.",
 }
+
+# Deliberately NOT listed above: /wallet-api/portfolio-v2::pop, whose HP action list
+# gained set_withdraw_vesting_route (the reference build emits only
+# delegate_vesting_shares and withdraw_vesting). A KNOWN_DIVERGENCES entry skips the
+# case entirely — status and content-type included — which would blind this large
+# aggregation endpoint to unrelated regressions. Its body is already exempt for a
+# better reason: balances and APR move every block, so the run-vs-run comparison puts
+# it in `loose`, which still checks status and content-type. Add an entry here only
+# for a divergence that is deterministic and not already loose.
 
 
 def diff(a_name, b_name, loose_name=None):


### PR DESCRIPTION
`HpActions()` returned only `delegate_vesting_shares` and `withdraw_vesting`. Both clients build their HP operation buttons from this list, so the withdraw routes UI each of them already implements had no direct entry point.

Adds `set_withdraw_vesting_route`, the chain operation name, matching the style of the two existing ids. Appended last because clients render actions in list order.

- parity `KNOWN_DIVERGENCES` entry for `/wallet-api/portfolio-v2::pop`, since the reference build emits the shorter list
- `WalletActionsTests` pins the HP ids and order, plus the savings-conditional HIVE/HBD builders

**Merge last.** Merging here deploys to production immediately, and the clients need to recognize the id first:

- ecency/ecency-mobile#3365 routes it to the existing withdraw routes section. Until a build carrying it is out, an older app renders an unlabeled control that lands on the generic transfer screen. It cannot broadcast anything, the ops builder throws on an unknown type, but it looks broken.
- ecency/vision-next#1241 adds the alias. Web drops ids it does not recognize, so merging ahead of it is harmless, the button just does not appear yet.
