### PR TITLE
chore: update renamed repo references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,8 +90,8 @@ jobs:
 
   # Roll the freshly-pushed image out to the running `vision_vapi` swarm service in each
   # region, so a vision-api change (e.g. rotating Feature Spotlight content) ships on its
-  # own instead of waiting for the next vision-next deploy. Mirrors the converge-wait that
-  # vision-next uses for `vision_web`. Assumes the swarm service is named `vision_vapi`
+  # own instead of waiting for the next vision-web deploy. Mirrors the converge-wait that
+  # vision-web uses for `vision_web`. Assumes the swarm service is named `vision_vapi`
   # (stack `vision`, service `vapi`) — verify once with `docker service ls`.
   deploy:
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Handlers are `public static async Task Name(HttpContext ctx)` methods on static 
 
 ## Upstream node failover
 
-`NodeHealthTracker` (adopted from the vision-next SDK) holds per-node health state: 429 responses park a node for `Retry-After` (or an escalating window), recent failures deprioritize it, and a latency EWMA orders the pool best-first with config order as tiebreak. Two clients build on it:
+`NodeHealthTracker` (adopted from the vision-web SDK) holds per-node health state: 429 responses park a node for `Retry-After` (or an escalating window), recent failures deprioritize it, and a latency EWMA orders the pool best-first with config order as tiebreak. Two clients build on it:
 
 - `HiveRpcClient` (Hive JSON-RPC): RPC-level errors (JSON `error` field) surface immediately without failover — they're application errors, not node health. The typed helpers additionally validate the result *shape* (`get_accounts` → array, `get_dynamic_global_properties` → object): a 200 with valid JSON but no usable result is a node failure that fails over — without this, a node serving malformed 200s is recorded as healthy and stays ranked first (observed in production as multi-hour windows of token-validation 401s).
 - `EngineRpcClient` (Hive-Engine): one instance per pool — the `/contracts` RPC pool and the history-API pool. The portfolio `Find` calls are fixed-shape queries that always yield a `result` array on a healthy node, so an error payload or non-JSON body *is* a node failure and rolls over to the next node. The raw passthroughs (`engine-api`, `engine-account-history`) fail over only on transport errors and 429/5xx; other responses belong to the caller's query and pipe as-is.

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ results, and how to regenerate the crypto golden vectors.
 To report a non-critical issue, please file an issue on this GitHub project.
 
 [//]: # 'LINKS'
-[ecency_vision]: https://github.com/ecency/vision-next
+[ecency_vision]: https://github.com/ecency/vision-web

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -47,7 +47,7 @@ dotnet/
 
 `HiveRpcClient` keeps the dhive `Client` parameters the Node service used
 (`timeout: 2000`, `failoverThreshold: 2`) but replaces dhive's simple ring
-failover with a health tracker adopted from the vision-next SDK's
+failover with a health tracker adopted from the vision-web SDK's
 `NodeHealthTracker` (simplified for a proxy's call rates):
 
 - **Per-node health state**: consecutive failures, rate-limit parking, and a


### PR DESCRIPTION
The web and mobile repos were renamed to `vision-web` and `vision-mobile`. Updates doc links and workflow comments accordingly. No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment comments to reference the current web application and convergence-wait behavior.
  * Corrected documentation to identify the web SDK as the source of node health tracking and failover functionality.
  * Updated repository links to point to the current web project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->