### PR TITLE
Release the check-in anchor when the check-in never reached the backend

### DIFF
--- a/dotnet/EcencyApi.Tests/CheckinGateTests.cs
+++ b/dotnet/EcencyApi.Tests/CheckinGateTests.cs
@@ -261,6 +261,41 @@ public class CheckinGateTests
     }
 
     [Fact]
+    public void AnUndeliveredCheckinGivesTheAnchorBack()
+    {
+        // The anchor is claimed before the upstream call. If the check-in never
+        // landed, holding it would absorb the account's next attempt on the
+        // strength of one that never happened.
+        var username = "release-" + Guid.NewGuid().ToString("n");
+        var nowMs = 1_700_000_000_000;
+
+        var reserved = CheckinGate.DecideAndReserve(username, nowMs);
+        Assert.NotNull(reserved.StampToStore);
+
+        CheckinGate.Release(username, reserved.StampToStore!);
+
+        Assert.True(CheckinGate.DecideAndReserve(username, nowMs + 1).Forward);
+    }
+
+    [Fact]
+    public void AReleaseCannotDiscardALaterAccountsAnchor()
+    {
+        // A release names the exact anchor it claimed, so a stale one arriving
+        // after the account has checked in again is a no-op.
+        var username = "stale-" + Guid.NewGuid().ToString("n");
+        var nowMs = 1_700_000_000_000;
+
+        var stale = CheckinGate.DecideAndReserve(username, nowMs).StampToStore!;
+        var current = CheckinGate.DecideAndReserve(username, nowMs + ClientPollIntervalMs).StampToStore!;
+        Assert.NotEqual(stale, current);
+
+        CheckinGate.Release(username, stale);
+
+        // The live anchor survives, so the window it opened still holds.
+        Assert.False(CheckinGate.DecideAndReserve(username, nowMs + ClientPollIntervalMs + 1).Forward);
+    }
+
+    [Fact]
     public void ABurstFromOneAccountStillCollapsesToOneUpstreamCall()
     {
         // The gate still has to do its job: repeated check-ins inside one window

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
@@ -79,6 +79,8 @@ public static partial class PrivateApi
         // ty === 10 (strict: JSON number equal to 10)
         var tyIsTen = ty is JsonValue tyVal && tyVal.TryGetValue<double>(out var tyNum) && tyNum == 10;
 
+        string? reservedAnchor = null;
+
         if (tyIsTen)
         {
             // Keyed on the account, not the caller's address: see CheckinGate for why
@@ -96,6 +98,8 @@ public static partial class PrivateApi
                 await ctx.SendJson(201, new JsonObject());
                 return;
             }
+
+            reservedAnchor = decision.StampToStore;
         }
 
         var pipeJson = new JsonObject
@@ -119,6 +123,17 @@ public static partial class PrivateApi
         }
 
         await Upstream.Pipe(ApiClient.ApiRequest("usr-activity", HttpMethod.Post, null, pipeJson), ctx);
+
+        // The anchor is claimed before the call, which is what closes the burst
+        // race. If the check-in then never reached the backend, give it back
+        // rather than absorb this account's next attempt on the strength of one
+        // that never landed. Pipe turns a transport failure into 504/500, so a
+        // 5xx here is exactly the "not delivered" set: an upstream 4xx is a
+        // deliberate rejection that a retry would not change.
+        if (reservedAnchor != null && ctx.Response.StatusCode >= 500)
+        {
+            CheckinGate.Release(username, reservedAnchor);
+        }
     }
 
     public static async Task SubscribeNewsletter(HttpContext ctx)

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
@@ -122,17 +122,34 @@ public static partial class PrivateApi
             pipeJson["tx"] = tx!.DeepClone();
         }
 
-        await Upstream.Pipe(ApiClient.ApiRequest("usr-activity", HttpMethod.Post, null, pipeJson), ctx);
-
         // The anchor is claimed before the call, which is what closes the burst
         // race. If the check-in then never reached the backend, give it back
         // rather than absorb this account's next attempt on the strength of one
-        // that never landed. Pipe turns a transport failure into 504/500, so a
-        // 5xx here is exactly the "not delivered" set: an upstream 4xx is a
-        // deliberate rejection that a retry would not change.
-        if (reservedAnchor != null && ctx.Response.StatusCode >= 500)
+        // that never landed.
+        var upstreamStarted = false;
+        try
         {
-            CheckinGate.Release(username, reservedAnchor);
+            // ApiRequest builds the auth headers eagerly and throws on a
+            // misconfigured deployment, so the request can fail before Pipe is
+            // ever entered. That is a check-in the backend never saw.
+            var upstream = ApiClient.ApiRequest("usr-activity", HttpMethod.Post, null, pipeJson);
+            upstreamStarted = true;
+            await Upstream.Pipe(upstream, ctx);
+        }
+        finally
+        {
+            // Pipe maps a transport failure to 504/500, so a 5xx is the "never
+            // reached the backend" set, as is a request that never started. An
+            // upstream 4xx is a deliberate rejection that a retry would not
+            // change, so it keeps the anchor. So does a backend answer that only
+            // failed on the way back to a client that went away: the check-in
+            // landed, and SendLikeExpress sets the upstream status before it
+            // writes, so the status still reports that here. The release has to
+            // sit in a finally, because Pipe can throw out of the write itself.
+            if (reservedAnchor != null && (!upstreamStarted || ctx.Response.StatusCode >= 500))
+            {
+                CheckinGate.Release(username, reservedAnchor);
+            }
         }
     }
 

--- a/dotnet/EcencyApi/Infrastructure/CheckinGate.cs
+++ b/dotnet/EcencyApi/Infrastructure/CheckinGate.cs
@@ -172,6 +172,39 @@ public static class CheckinGate
         }
     }
 
+    /// <summary>
+    /// Gives up an anchor whose check-in never reached the backend.
+    ///
+    /// The anchor is reserved before the upstream call, because that is what
+    /// closes the burst race. If the call then fails to deliver, holding the
+    /// anchor would absorb the account's next attempt on the strength of a
+    /// check-in that never happened, which is the failure this whole gate is
+    /// being fixed for. Releasing puts the account back where it started.
+    ///
+    /// Only an anchor still holding <paramref name="stamp"/> is removed, so this
+    /// can never discard one a later check-in established.
+    /// </summary>
+    public static void Release(string username, string stamp)
+    {
+        var key = CacheKey(username);
+
+        lock (StripeFor(key))
+        {
+            try
+            {
+                if (MemCache.Get<string>(key) == stamp)
+                {
+                    MemCache.Del(key);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e);
+                Console.Error.WriteLine("Cache release failed.");
+            }
+        }
+    }
+
     private const int StripeCount = 64;
 
     private static readonly object[] Stripes =

--- a/dotnet/EcencyApi/Infrastructure/CheckinGate.cs
+++ b/dotnet/EcencyApi/Infrastructure/CheckinGate.cs
@@ -126,8 +126,9 @@ public static class CheckinGate
     /// The three have to happen together. Two check-ins for one account can
     /// arrive in the same instant (two tabs opening at once both fire the ping
     /// their page load schedules). If both read the anchor before either writes,
-    /// both are forwarded, which is the burst this gate exists to collapse. Serializing them makes a concurrent duplicate behave exactly
-    /// like a sequential one: the second reads the anchor the first just wrote
+    /// both are forwarded, which is the burst this gate exists to collapse.
+    /// Serializing them makes a concurrent duplicate behave exactly like a
+    /// sequential one: the second reads the anchor the first just wrote
     /// and is absorbed. That stays correct in the direction this gate cares
     /// about, because a check-in milliseconds behind another is one the backend
     /// refuses regardless.
@@ -197,10 +198,13 @@ public static class CheckinGate
                     MemCache.Del(key);
                 }
             }
-            catch (Exception e)
+            catch
             {
-                Console.Error.WriteLine(e);
-                Console.Error.WriteLine("Cache release failed.");
+                // Deliberately silent as well as swallowed. This runs after the
+                // response has been written, so letting it escape would raise an
+                // error the client can no longer be told about. A cache throwing
+                // here is already saying so from the read and the write on the way
+                // in. A request handler should not be adding logging of its own.
             }
         }
     }


### PR DESCRIPTION
Closes #70. Follow-up to #69, from a Qodo finding that landed on that PR after it merged.

The gate claims its anchor before the upstream call, which is what makes the burst race safe to close. The cost was that a check-in which never reached the backend still held the window: on an upstream timeout or 5xx, another attempt for that account inside the window was absorbed with a 201 even though nothing had been recorded. That is the same shape as the bug #69 fixed, with a narrower trigger.

### Change

`CheckinGate.Release(username, stamp)` gives the anchor back, and the handler calls it when the piped response came back 5xx. `Upstream.Pipe` turns a transport failure into 504/500, so a 5xx is exactly the "not delivered" set. An upstream 4xx is a deliberate rejection that a retry would not change, so it keeps the window.

The release names the exact anchor it claimed and removes only that one, under the same stripe lock as the reservation, so a stale release arriving after the account has checked in again cannot discard the live anchor. Both properties are pinned by tests.

### Alternative considered and rejected

Awaiting the upstream result and stamping only on success. Two problems: it means hand-rolling the Express-compatible response path that `Pipe` owns, which invariant 3 protects, and a 2xx from the backend does not mean the check-in was credited anyway, since its verifier decides that asynchronously. Releasing on a known non-delivery gets the part that is actually knowable here.

### Tests

`AnUndeliveredCheckinGivesTheAnchorBack` and `AReleaseCannotDiscardALaterAccountsAnchor`. Full suite green: 130 passed, build clean with no warnings.
