### PR TITLE
SSR RPC cache: use the dotted method form so bridge reads reach hivemind

### DIFF
--- a/dotnet/EcencyApi.Tests/SsrRpcTests.cs
+++ b/dotnet/EcencyApi.Tests/SsrRpcTests.cs
@@ -27,6 +27,7 @@ public class SsrRpcTests
         public int DelayMs;
         public bool RpcError;
         public bool NullResult;
+        public volatile string LastMethod = "";
 
         public RpcStub()
         {
@@ -53,10 +54,27 @@ public class SsrRpcTests
                 {
                     reqBody = await reader.ReadToEndAsync();
                 }
-                var method = JsonNode.Parse(reqBody)?["params"]?[1]?.GetValue<string>() ?? "?";
+                // hived semantics: the legacy `call` envelope resolves only hived
+                // APIs, so a bridge read sent that way is an RPC error; the dotted
+                // form (`bridge.get_post`) is routed to hivemind.
+                var req = JsonNode.Parse(reqBody);
+                var rawMethod = req?["method"]?.GetValue<string>() ?? "?";
+                string method;
+                var legacyBridge = false;
+                if (rawMethod == "call")
+                {
+                    var api = req?["params"]?[0]?.GetValue<string>() ?? "?";
+                    method = req?["params"]?[1]?.GetValue<string>() ?? "?";
+                    legacyBridge = api == "bridge";
+                }
+                else
+                {
+                    method = rawMethod.Contains('.') ? rawMethod[(rawMethod.IndexOf('.') + 1)..] : rawMethod;
+                }
+                LastMethod = rawMethod;
                 if (DelayMs > 0) await Task.Delay(DelayMs);
-                var body = RpcError
-                    ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"message\":\"stub error\"}}"
+                var body = RpcError || legacyBridge
+                    ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"message\":\"" + (legacyBridge ? "Assert Exception:api_itr != data._registered_apis.end(): Could not find API bridge" : "stub error") + "\"}}"
                     : NullResult
                         ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}"
                         : "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"method\":\"" + method + "\",\"n\":" + n + ",\"text\":\"caf\\u00e9 \\ud83d\"}}";
@@ -107,6 +125,22 @@ public class SsrRpcTests
         var bodies = results.Select(r => Encoding.UTF8.GetString(r.Bytes)).Distinct().ToArray();
         Assert.Single(bodies);
         Assert.Contains("\"method\":\"get_post\"", bodies[0]);
+    }
+
+    [Fact]
+    public async Task Reads_use_the_dotted_method_form_so_bridge_reaches_hivemind()
+    {
+        await using var stub = new RpcStub();
+        Use(stub);
+        var r = await SsrRpc.Resolve(Post, P("a", "b"));
+        Assert.Equal(SsrRpc.Outcome.Miss, r.Outcome);
+        Assert.Equal("bridge.get_post", stub.LastMethod);
+        var props = await SsrRpc.Resolve(Props, new JsonArray());
+        Assert.Equal(SsrRpc.Outcome.Miss, props.Outcome);
+        Assert.Equal("condenser_api.get_dynamic_global_properties", stub.LastMethod);
+        // The legacy envelope would have been refused for bridge, as hived does.
+        var legacy = new HiveRpcClient(new[] { stub.Url }, timeoutMs: 1000, failoverThreshold: 1);
+        await Assert.ThrowsAsync<HiveRpcClient.RpcException>(() => legacy.Call("bridge", "get_post", P("a", "b")));
     }
 
     [Fact]

--- a/dotnet/EcencyApi/Handlers/SsrRpc.cs
+++ b/dotnet/EcencyApi/Handlers/SsrRpc.cs
@@ -349,10 +349,12 @@ public static partial class SsrRpc
                 }
             }
             var started = Environment.TickCount64;
-            // Call() places params inside its own request envelope; a node that
-            // already hangs off the request body cannot be re-parented, so it
-            // travels as a clone.
-            var result = await Client.Call(policy.Api, policy.Method, @params.DeepClone());
+            // The dotted method form: hived's legacy `call` dispatcher has no API
+            // named `bridge` (found on alpha: every bridge read failed with
+            // "Could not find API bridge"), while `bridge.get_post` is routed to
+            // hivemind. The node already hangs off the request body and cannot be
+            // re-parented into the envelope, so it travels as a clone.
+            var result = await Client.CallMethod($"{policy.Api}.{policy.Method}", @params.DeepClone());
             var bytes = Encoding.UTF8.GetBytes(result is null ? "null" : JsJson.Stringify(result));
             counter.RecordUpstream(Environment.TickCount64 - started);
             Cache.Set(key, bytes, policy.TtlMs);

--- a/dotnet/EcencyApi/Infrastructure/HiveRpcClient.cs
+++ b/dotnet/EcencyApi/Infrastructure/HiveRpcClient.cs
@@ -66,10 +66,13 @@ public sealed class HiveRpcClient
     /// valid 200 with a usable array, so shape validation passes and the latency EWMA
     /// keeps such a node ranked first — silently blanking every metadata-derived
     /// feature (portfolio engine/chain token visibility) with no error and no log.</param>
-    public async Task<JsonNode?> Call(string api, string method, JsonNode @params,
+    public Task<JsonNode?> Call(string api, string method, JsonNode @params,
         Func<JsonNode?, bool>? validateResult = null,
         Func<JsonNode?, bool>? preferResult = null)
     {
+        // The legacy `call` envelope the Node service always sent. hived resolves
+        // it for its own APIs (condenser_api, database_api); hivemind's `bridge`
+        // is not one of them, so bridge reads must use CallMethod.
         var request = new JsonObject
         {
             ["id"] = Interlocked.Increment(ref _seq),
@@ -77,6 +80,32 @@ public sealed class HiveRpcClient
             ["method"] = "call",
             ["params"] = new JsonArray(api, method, @params),
         };
+        return Send(request, method, validateResult, preferResult);
+    }
+
+    /// <summary>
+    /// The modern JSON-RPC form, `"method": "bridge.get_post"` with the params
+    /// as given, which jussi/HAF route to hived or hivemind by prefix. Needed
+    /// for every hivemind (`bridge`) read; works for condenser_api too.
+    /// </summary>
+    public Task<JsonNode?> CallMethod(string qualifiedMethod, JsonNode @params,
+        Func<JsonNode?, bool>? validateResult = null,
+        Func<JsonNode?, bool>? preferResult = null)
+    {
+        var request = new JsonObject
+        {
+            ["id"] = Interlocked.Increment(ref _seq),
+            ["jsonrpc"] = "2.0",
+            ["method"] = qualifiedMethod,
+            ["params"] = @params,
+        };
+        return Send(request, qualifiedMethod, validateResult, preferResult);
+    }
+
+    private async Task<JsonNode?> Send(JsonObject request, string method,
+        Func<JsonNode?, bool>? validateResult,
+        Func<JsonNode?, bool>? preferResult)
+    {
         // JsJson: a lone-surrogate username from a client token must serialize
         // (JSON.stringify semantics) instead of throwing in the writer.
         var body = JsJson.Stringify(request);


### PR DESCRIPTION
Staging showed the SSR RPC cache failing every `bridge.*` read with `Could not find API bridge` while `condenser_api.*` reads were hitting. The cache used `HiveRpcClient.Call`, whose legacy `{"method":"call","params":[api, method, params]}` envelope hived resolves only for its own APIs; hivemind's `bridge` is routed by the dotted method name, which is the form the web SDK already sends.

- `HiveRpcClient.CallMethod(qualifiedMethod, params)` sends `"method":"bridge.get_post"` (works for condenser_api too); `Call` keeps the legacy envelope for existing callers; both share one `Send` loop.
- `SsrRpc.Fill` uses `CallMethod` for every read.
- The test stub now emulates hived's refusal of the legacy form for bridge; the new test asserts the dotted form for a bridge and a condenser_api read and that the legacy call is refused.

Same change as 683b100a, which landed on the #74 branch after that PR had merged.