### PR TITLE
RPC pool: park only a node that is not answering

### DIFF
--- a/dotnet/EcencyApi.Tests/HiveRpcFailoverTests.cs
+++ b/dotnet/EcencyApi.Tests/HiveRpcFailoverTests.cs
@@ -346,6 +346,57 @@ public class HiveRpcFailoverTests
     }
 
     [Fact]
+    public async Task AHealthyNodeWithOverlappingTimeouts_IsNotParked()
+    {
+        // Production shape: the node that answers ~98% of calls has three
+        // heavy queries time out at once. Three "consecutive" failures, yet it
+        // is answering everything else; parking it would push the load onto
+        // weaker nodes. Only a node that is not answering gets parked.
+        var hang = false;
+        await using var busy = new StubNode(() => hang ? -1 : 200);
+        await using var spare = new StubNode(() => 200);
+        long now = 0;
+        var client = new HiveRpcClient(new[] { busy.Url, spare.Url }, timeoutMs: 200, failoverThreshold: 1, clock: () => now);
+
+        for (var i = 0; i < 40; i++)
+        {
+            await client.Call("condenser_api", "get_accounts", new JsonArray());
+        }
+        // Three overlapping timeouts (sequential here is the strictest form of
+        // "consecutive"; the stub's single-threaded loop makes them serial).
+        hang = true;
+        for (var i = 0; i < 3; i++)
+        {
+            now += 31_000; // past the recent-failure demotion, so it is retried
+            await client.Call("condenser_api", "get_accounts", new JsonArray());
+        }
+        hang = false;
+        var view = client.HealthSnapshot()[0]!;
+        Assert.Equal(3, view["consecutive_failures"]!.GetValue<int>());
+        Assert.Equal(0, view["parked_for_ms"]!.GetValue<long>());
+        Assert.True(view["failure_rate"]!.GetValue<double>() < 0.5);
+
+        // With an alternative available the ranking stops trying it, so its
+        // fraction can only climb where it keeps being tried: a node that is the
+        // only option and keeps failing crosses the fraction and is parked.
+        var dying = false;
+        await using var only = new StubNode(() => dying ? -1 : 200);
+        var lone = new HiveRpcClient(new[] { only.Url }, timeoutMs: 200, failoverThreshold: 1, clock: () => now);
+        for (var i = 0; i < 10; i++)
+        {
+            await lone.Call("condenser_api", "get_accounts", new JsonArray());
+        }
+        dying = true;
+        for (var i = 0; i < 8; i++)
+        {
+            await Assert.ThrowsAnyAsync<Exception>(() => lone.Call("condenser_api", "get_accounts", new JsonArray()));
+        }
+        view = lone.HealthSnapshot()[0]!;
+        Assert.True(view["failure_rate"]!.GetValue<double>() >= 0.5);
+        Assert.True(view["parked_for_ms"]!.GetValue<long>() > 0);
+    }
+
+    [Fact]
     public async Task RateLimits_DoNotCountTowardFailureParking()
     {
         // 429s have their own parking and a throttled node is responsive: two

--- a/dotnet/EcencyApi.Tests/HiveRpcFailoverTests.cs
+++ b/dotnet/EcencyApi.Tests/HiveRpcFailoverTests.cs
@@ -362,14 +362,12 @@ public class HiveRpcFailoverTests
         {
             await client.Call("condenser_api", "get_accounts", new JsonArray());
         }
-        // Three overlapping timeouts (sequential here is the strictest form of
-        // "consecutive"; the stub's single-threaded loop makes them serial).
+        // Three overlapping timeouts: the calls start together, each holding an
+        // ordering with the busy node first, and all three fail on it at the
+        // same time before failing over to the spare.
         hang = true;
-        for (var i = 0; i < 3; i++)
-        {
-            now += 31_000; // past the recent-failure demotion, so it is retried
-            await client.Call("condenser_api", "get_accounts", new JsonArray());
-        }
+        await Task.WhenAll(Enumerable.Range(0, 3)
+            .Select(_ => client.Call("condenser_api", "get_accounts", new JsonArray())));
         hang = false;
         var view = client.HealthSnapshot()[0]!;
         Assert.Equal(3, view["consecutive_failures"]!.GetValue<int>());

--- a/dotnet/EcencyApi/Infrastructure/HiveRpcClient.cs
+++ b/dotnet/EcencyApi/Infrastructure/HiveRpcClient.cs
@@ -67,6 +67,7 @@ public sealed class HiveRpcClient
                 ["recent_failure"] = v.RecentFailure,
                 ["rate_limited_for_ms"] = v.RateLimitedForMs,
                 ["parked_for_ms"] = v.FailureParkedForMs,
+                ["failure_rate"] = Math.Round(v.FailureRate, 3),
             });
         }
         return arr;

--- a/dotnet/EcencyApi/Infrastructure/NodeHealthTracker.cs
+++ b/dotnet/EcencyApi/Infrastructure/NodeHealthTracker.cs
@@ -40,6 +40,13 @@ public sealed class NodeHealthTracker
     private const int FailureParkThreshold = 3;
     private const int FailureParkBaseMs = 30_000;
     private const int FailureParkMaxMs = 120_000;
+    // Under concurrency "consecutive" is not "sequential": with hundreds of
+    // calls in flight, three overlapping timeouts of a heavy query satisfy the
+    // count while the node is answering everything else. Parking therefore
+    // also needs the node to have never answered, or to be failing most of its
+    // recent calls (an EWMA of the failure fraction, alpha 0.1).
+    private const double FailureRateAlpha = 0.1;
+    private const double FailureRateParkFloor = 0.5;
 
     private sealed class NodeHealth
     {
@@ -50,6 +57,8 @@ public sealed class NodeHealthTracker
         public long LastRateLimitAtMs;
         public long FailureParkedUntilMs;
         public int FailureParkStreak;
+        // Recent failure fraction (1 = every recent call failed).
+        public double FailureRate;
         // Hard failures only (timeouts, refusals, bad answers), never 429s: a
         // throttled node is responsive and has its own parking.
         public int ConsecutiveHardFailures;
@@ -67,7 +76,7 @@ public sealed class NodeHealthTracker
     public sealed record NodeView(
         int Index, long Calls, long Successes, long Failures, long Timeouts, long RateLimits,
         double? EwmaLatencyMs, int LatencySamples, int ConsecutiveFailures,
-        bool RecentFailure, long RateLimitedForMs, long FailureParkedForMs);
+        bool RecentFailure, long RateLimitedForMs, long FailureParkedForMs, double FailureRate);
 
     private readonly NodeHealth[] _health;
     private readonly object _lock = new();
@@ -94,6 +103,7 @@ public sealed class NodeHealthTracker
             var h = _health[nodeIndex];
             h.Calls++;
             h.Successes++;
+            h.FailureRate *= 1 - FailureRateAlpha;
             h.ConsecutiveFailures = 0;
             h.ConsecutiveHardFailures = 0;
             h.RateLimitStreak = 0;
@@ -122,6 +132,7 @@ public sealed class NodeHealthTracker
             h.Calls++;
             h.Failures++;
             if (timedOut) h.Timeouts++;
+            h.FailureRate = h.FailureRate * (1 - FailureRateAlpha) + FailureRateAlpha;
             h.ConsecutiveFailures++;
             h.ConsecutiveHardFailures++;
             h.LastFailureAtMs = now;
@@ -136,7 +147,8 @@ public sealed class NodeHealthTracker
             {
                 RecordLatency(h, elapsedMs);
             }
-            if (h.ConsecutiveHardFailures >= FailureParkThreshold)
+            var notAnswering = h.Successes == 0 || h.FailureRate >= FailureRateParkFloor;
+            if (h.ConsecutiveHardFailures >= FailureParkThreshold && notAnswering)
             {
                 var parkMs = Math.Min(FailureParkBaseMs << Math.Min(h.FailureParkStreak, 2), FailureParkMaxMs);
                 h.FailureParkedUntilMs = now + parkMs;
@@ -284,7 +296,8 @@ public sealed class NodeHealthTracker
                 return new NodeView(i, h.Calls, h.Successes, h.Failures, h.Timeouts, h.RateLimits,
                     h.EwmaLatencyMs, h.LatencySampleCount, h.ConsecutiveFailures,
                     h.ConsecutiveFailures > 0 && now - h.LastFailureAtMs < RecentFailureWindowMs,
-                    Math.Max(0, h.RateLimitedUntilMs - now), Math.Max(0, h.FailureParkedUntilMs - now));
+                    Math.Max(0, h.RateLimitedUntilMs - now), Math.Max(0, h.FailureParkedUntilMs - now),
+                    h.FailureRate);
             }).ToList();
         }
     }


### PR DESCRIPTION
Closes #78.

Minutes after #77 deployed, one origin's per-node stats showed the node answering ~98% of the cache's upstream calls failure-parked three times in three minutes (escalating to 120s) while five of seven nodes were parked or rate-limited at once. The node was fine for cheap calls; heavy feed queries were timing out on it, and with ~150 calls in flight three overlapping heavy timeouts satisfy "three consecutive failures" even though successes arrive every few milliseconds.

- `NodeHealthTracker` keeps a recent failure fraction per node (EWMA, alpha 0.1: a success multiplies by 0.9, a failure adds 0.1). Failure parking now requires, besides the consecutive count, that the node has never answered or that its fraction is at least one half. A node that never answered (the case #77 was built for) still parks on the third failure; a node answering almost everything is not parked by overlapping blips, and a single failed probe after a park no longer re-parks it unless it is still failing most calls.
- `failure_rate` is reported per node in `/private-api/ssr/stats`.
- Tests: a node with 40 answers and three timeouts in a row keeps consecutive_failures 3, fraction under one half, not parked; a lone node that stops answering crosses the fraction and is parked; the existing dead-node, retry, half-open and rate-limit tests are unchanged. 164 total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved RPC failover reliability during overlapping or concurrent timeouts.
  * Healthy nodes are less likely to be incorrectly removed from service when they continue responding successfully.
  * Node health evaluation now considers the broader recent failure rate, rather than consecutive failures alone.
  * Health information now includes each node’s recent failure rate for clearer monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->