### PR TITLE
feat(promoted): apply the moderation mute list to promoted entries

### DIFF
--- a/dotnet/EcencyApi.Tests/ModerationMutesTests.cs
+++ b/dotnet/EcencyApi.Tests/ModerationMutesTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json.Nodes;
+using EcencyApi.Infrastructure;
+using Xunit;
+
+namespace EcencyApi.Tests;
+
+/// <summary>
+/// The moderation mute filter on promoted entries. The list is fetched from
+/// chain, but the parts that can silently break a feed are pure: an empty or
+/// unreadable list must leave the feed alone, and a match must remove exactly
+/// the muted author's entries and nothing else.
+/// </summary>
+public class ModerationMutesTests
+{
+    private static JsonArray Entries(params string?[] authors)
+    {
+        var arr = new JsonArray();
+        foreach (var a in authors)
+        {
+            var o = new JsonObject { ["permlink"] = "p-" + (a ?? "none") };
+            if (a != null)
+            {
+                o["author"] = a;
+            }
+            arr.Add(o);
+        }
+        return arr;
+    }
+
+    private static string?[] AuthorsOf(JsonArray arr) =>
+        arr.Select(e => e is JsonObject o && o.TryGetPropertyValue("author", out var a)
+            ? a?.GetValue<string>()
+            : null).ToArray();
+
+    [Fact]
+    public void AnEmptyMuteListLeavesTheFeedUntouched()
+    {
+        var entries = Entries("alice", "bob");
+        var result = ModerationMutes.FilterMutedAuthors(entries, ModerationMutes.ToSet(Array.Empty<string>()));
+        Assert.Equal(new[] { "alice", "bob" }, AuthorsOf(result));
+    }
+
+    [Fact]
+    public void MutedAuthorsAreDroppedAndTheRestKeptInOrder()
+    {
+        var entries = Entries("alice", "spammer", "bob", "spammer", "carol");
+        var result = ModerationMutes.FilterMutedAuthors(entries, ModerationMutes.ToSet(new[] { "spammer" }));
+        Assert.Equal(new[] { "alice", "bob", "carol" }, AuthorsOf(result));
+    }
+
+    [Fact]
+    public void MatchingIsCaseInsensitive()
+    {
+        // Hive account names are lowercase, but nothing here guarantees the two
+        // sides were normalized by the same code path.
+        var entries = Entries("Spammer");
+        var result = ModerationMutes.FilterMutedAuthors(entries, ModerationMutes.ToSet(new[] { "spammer" }));
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AnEntryWithNoAuthorIsKept()
+    {
+        // An unreadable shape is not evidence of anything; dropping it would
+        // shrink the feed for a reason nobody could see.
+        var entries = Entries("alice", null);
+        var result = ModerationMutes.FilterMutedAuthors(entries, ModerationMutes.ToSet(new[] { "spammer" }));
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void FilteringEveryEntryYieldsAnEmptyArrayNotNull()
+    {
+        var entries = Entries("spammer", "spammer");
+        var result = ModerationMutes.FilterMutedAuthors(entries, ModerationMutes.ToSet(new[] { "spammer" }));
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ReadFollowingTakesTheFollowingNamesAndSkipsUnusableRows()
+    {
+        var rows = new JsonArray(
+            new JsonObject { ["follower"] = "ecency", ["following"] = "spammer", ["what"] = new JsonArray("ignore") },
+            new JsonObject { ["follower"] = "ecency" },
+            new JsonObject { ["follower"] = "ecency", ["following"] = "" },
+            new JsonObject { ["follower"] = "ecency", ["following"] = "phisher", ["what"] = new JsonArray("ignore") });
+
+        Assert.Equal(new[] { "spammer", "phisher" }, ModerationMutes.ReadFollowing(rows));
+    }
+
+    [Fact]
+    public void TheModerationAccountIsEcency()
+    {
+        // Pinned: this account name is the whole control surface. A typo here
+        // would read as "nobody is muted" with no error anywhere.
+        Assert.Equal("ecency", ModerationMutes.Account);
+    }
+}

--- a/dotnet/EcencyApi.Tests/ModerationMutesTests.cs
+++ b/dotnet/EcencyApi.Tests/ModerationMutesTests.cs
@@ -90,6 +90,37 @@ public class ModerationMutesTests
     }
 
     [Fact]
+    public void AnAuthorThatCannotBeReadAsAStringDoesNotThrow()
+    {
+        // GetValue<string>() throws on a lone-surrogate escape, which JSON.parse
+        // accepts and Hive nodes do emit. Throwing here would fail the whole
+        // promoted-entries request over one malformed name.
+        var entries = new JsonArray(
+            new JsonObject { ["author"] = 42 },
+            new JsonObject { ["author"] = JsonValue.Create((string?)null) },
+            new JsonObject { ["author"] = new JsonObject() },
+            new JsonObject { ["author"] = "spammer" });
+
+        var result = ModerationMutes.FilterMutedAuthors(entries, ModerationMutes.ToSet(new[] { "spammer" }));
+
+        // The three unreadable ones survive; only the match is dropped.
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public void AFollowingThatCannotBeReadAsAStringIsSkippedNotFatal()
+    {
+        // Same reasoning on the refresh side: one malformed row must not abort
+        // the mute-list refresh and leave the feed unfiltered.
+        var rows = new JsonArray(
+            new JsonObject { ["following"] = 7 },
+            new JsonObject { ["following"] = new JsonArray("nested") },
+            new JsonObject { ["following"] = "spammer" });
+
+        Assert.Equal(new[] { "spammer" }, ModerationMutes.ReadFollowing(rows));
+    }
+
+    [Fact]
     public void TheModerationAccountIsEcency()
     {
         // Pinned: this account name is the whole control surface. A typo here

--- a/dotnet/EcencyApi.Tests/ModerationMutesTests.cs
+++ b/dotnet/EcencyApi.Tests/ModerationMutesTests.cs
@@ -12,6 +12,9 @@ namespace EcencyApi.Tests;
 /// </summary>
 public class ModerationMutesTests
 {
+    private static long TotalRpcCalls() =>
+        ModerationMutes.Rpc.HealthSnapshot().Sum(n => n!["calls"]!.GetValue<long>());
+
     private static JsonArray Entries(params string?[] authors)
     {
         var arr = new JsonArray();
@@ -118,6 +121,72 @@ public class ModerationMutesTests
             new JsonObject { ["following"] = "spammer" });
 
         Assert.Equal(new[] { "spammer" }, ModerationMutes.ReadFollowing(rows));
+    }
+
+    [Fact]
+    public async Task AFailedRefreshIsCachedSoQueuedRequestsDoNotEachRetry()
+    {
+        // The refresh gate serializes callers. Without caching the failure, a
+        // dead node pool makes that worse than no gate at all: each queued
+        // request waits out the one ahead of it and then runs its own full
+        // failover sweep, so the Nth caller pays N times the timeout budget.
+        var original = ModerationMutes.Rpc;
+        MemCache.Del("moderation-muted-authors");
+        MemCache.Del("moderation-muted-authors-last-good");
+
+        // Port 9 (discard) refuses immediately, so this measures the code path
+        // rather than a real network timeout.
+        ModerationMutes.Rpc = new HiveRpcClient(
+            new[] { "http://127.0.0.1:9/" }, timeoutMs: 250, failoverThreshold: 1);
+
+        try
+        {
+            var first = await ModerationMutes.Get();
+            Assert.Empty(first);
+
+            // Count attempts rather than elapsed time: a refused connection
+            // fails in microseconds, so a timing assertion passes just as
+            // happily whether or not the failure was cached.
+            var callsAfterFirst = TotalRpcCalls();
+
+            var followers = await Task.WhenAll(
+                Enumerable.Range(0, 8).Select(_ => ModerationMutes.Get()));
+
+            Assert.All(followers, f => Assert.Empty(f));
+            Assert.Equal(callsAfterFirst, TotalRpcCalls());
+        }
+        finally
+        {
+            ModerationMutes.Rpc = original;
+            MemCache.Del("moderation-muted-authors");
+            MemCache.Del("moderation-muted-authors-last-good");
+        }
+    }
+
+    [Fact]
+    public async Task AFailedRefreshFallsBackToTheLastListSeen()
+    {
+        var original = ModerationMutes.Rpc;
+        MemCache.Del("moderation-muted-authors");
+
+        // Stand in for a previously successful fetch.
+        MemCache.Set("moderation-muted-authors-last-good", new[] { "spammer" });
+        ModerationMutes.Rpc = new HiveRpcClient(
+            new[] { "http://127.0.0.1:9/" }, timeoutMs: 250, failoverThreshold: 1);
+
+        try
+        {
+            // Stale filtering, not no filtering: an unreachable pool must not be
+            // a way for a muted account back into the feed.
+            var muted = await ModerationMutes.Get();
+            Assert.Equal(new[] { "spammer" }, muted.OrderBy(x => x));
+        }
+        finally
+        {
+            ModerationMutes.Rpc = original;
+            MemCache.Del("moderation-muted-authors");
+            MemCache.Del("moderation-muted-authors-last-good");
+        }
     }
 
     [Fact]

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Feeds.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Feeds.cs
@@ -68,6 +68,15 @@ public static partial class PrivateApi
         var shortContent = double.IsNaN(shortNum) ? 0 : (int)Math.Clamp(shortNum, int.MinValue, int.MaxValue);
 
         var posts = await ApiClient.GetPromotedEntries(limit, shortContent);
+
+        // Promoted entries are served from here, not from the waves indexer, so
+        // the moderation mute list has to be applied on this path too. A muted
+        // account buying a promoted slot would otherwise land in the most
+        // prominent position in the feed. Filtered after the cache read rather
+        // than before it, so a new mute takes effect on the mute list's own
+        // refresh instead of waiting out the promoted cache.
+        posts = ModerationMutes.FilterMutedAuthors(posts, await ModerationMutes.Get());
+
         await ctx.SendJson(200, posts);
     }
 

--- a/dotnet/EcencyApi/Infrastructure/ModerationMutes.cs
+++ b/dotnet/EcencyApi/Infrastructure/ModerationMutes.cs
@@ -30,6 +30,22 @@ public static class ModerationMutes
 
     private const double TtlSeconds = 300;
 
+    /// <summary>
+    /// How long a failed refresh is held before trying again. Short, so a blip
+    /// costs one interval of stale filtering, but not zero: caching the failure
+    /// is what stops every request behind the gate from running its own full
+    /// node-failover sweep.
+    /// </summary>
+    private const double FailureTtlSeconds = 30;
+
+    /// <summary>
+    /// How long a request waits for someone else's refresh before answering from
+    /// what it already has. A normal refresh is one RPC round trip, so waiters
+    /// get the real list; this only bounds the pathological case where the whole
+    /// node pool is timing out and the refresh takes tens of seconds.
+    /// </summary>
+    private static readonly TimeSpan RefreshWait = TimeSpan.FromSeconds(2);
+
     /// <summary>condenser_api.get_following caps a single response at 1000 rows.</summary>
     private const int PageSize = 1000;
 
@@ -63,7 +79,14 @@ public static class ModerationMutes
             return ToSet(cached);
         }
 
-        await RefreshGate.WaitAsync();
+        if (!await RefreshGate.WaitAsync(RefreshWait))
+        {
+            // A refresh is already running and is taking far longer than one RPC
+            // round trip. Queueing behind it would hand that latency to a
+            // promoted-entries request, so answer from the fallback instead.
+            return ToSet(MemCache.Get<string[]>(LastGoodCacheKey) ?? Array.Empty<string>());
+        }
+
         try
         {
             // Someone else may have refreshed while this request queued.
@@ -103,18 +126,17 @@ public static class ModerationMutes
         {
             // Deliberately silent: this runs on the promoted-entries request path
             // and the service keeps its logs quiet there (CLAUDE.md, "No hot-path
-            // logging"). The fallback below is what makes the failure survivable.
-            //
-            // Re-arm the short TTL with the stale list so a node outage does not
-            // put an RPC call on every promoted-entries request for its duration.
-            var lastGood = MemCache.Get<string[]>(LastGoodCacheKey);
-            if (lastGood != null)
-            {
-                MemCache.Set(CacheKey, lastGood, TtlSeconds);
-                return lastGood;
-            }
+            // logging"). The caching below is what makes the failure survivable.
+            var fallback = MemCache.Get<string[]>(LastGoodCacheKey) ?? Array.Empty<string>();
 
-            return Array.Empty<string>();
+            // Cache the failure, including the empty one. Without this the gate
+            // above turns a node outage into something worse than no gate at all:
+            // each queued request waits out the one ahead of it and then runs its
+            // own full failover sweep, so the Nth caller pays N times the timeout
+            // budget. Caching lets every waiter answer immediately and puts one
+            // retry on the clock instead of one per request.
+            MemCache.Set(CacheKey, fallback, FailureTtlSeconds);
+            return fallback;
         }
     }
 

--- a/dotnet/EcencyApi/Infrastructure/ModerationMutes.cs
+++ b/dotnet/EcencyApi/Infrastructure/ModerationMutes.cs
@@ -1,0 +1,176 @@
+using System.Text.Json.Nodes;
+
+namespace EcencyApi.Infrastructure;
+
+/// <summary>
+/// Ecency's on-chain moderation mute list.
+///
+/// Muting an account from the moderation account is how spam and phishing are
+/// kept out of the waves feeds; esync applies that list to every waves query it
+/// serves. Promoted entries never go through esync, so without this they were
+/// the one surface a muted account could still reach an audience through — and
+/// the most prominent one, since a promoted card is a paid placement.
+///
+/// Read straight from chain rather than from another service so this holds even
+/// if the indexer is behind, and cached because the list changes only when a
+/// moderator acts on it.
+/// </summary>
+public static class ModerationMutes
+{
+    /// <summary>The account whose mutes are treated as platform-wide.</summary>
+    public const string Account = "ecency";
+
+    private const string CacheKey = "moderation-muted-authors";
+
+    /// <summary>
+    /// Survives a failed refresh, so an unreachable node degrades to the list we
+    /// last saw rather than to no filtering at all. Never expires on purpose.
+    /// </summary>
+    private const string LastGoodCacheKey = "moderation-muted-authors-last-good";
+
+    private const double TtlSeconds = 300;
+
+    /// <summary>condenser_api.get_following caps a single response at 1000 rows.</summary>
+    private const int PageSize = 1000;
+
+    /// <summary>
+    /// Bounds the paging loop. 20 pages is 20k muted accounts, far past any real
+    /// list, so a node that stops advancing the cursor truncates rather than
+    /// looping forever.
+    /// </summary>
+    private const int MaxPages = 20;
+
+    /// <summary>Replaceable for tests (loopback stub nodes).</summary>
+    internal static HiveRpcClient Rpc = HiveClients.Default;
+
+    /// <summary>
+    /// The muted accounts, cached. Returns an empty set rather than throwing:
+    /// a moderation filter that cannot load must not take a feed down with it.
+    /// </summary>
+    public static async Task<HashSet<string>> Get()
+    {
+        var cached = MemCache.Get<string[]>(CacheKey);
+        if (cached != null)
+        {
+            return ToSet(cached);
+        }
+
+        try
+        {
+            var names = await Fetch();
+            MemCache.Set(CacheKey, names, TtlSeconds);
+            MemCache.Set(LastGoodCacheKey, names);
+            return ToSet(names);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"warn: failed to fetch moderation mutes {e.Message}");
+
+            // Re-arm the short TTL with the stale list so a node outage does not
+            // put an RPC call on every promoted-entries request for its duration.
+            var lastGood = MemCache.Get<string[]>(LastGoodCacheKey);
+            if (lastGood != null)
+            {
+                MemCache.Set(CacheKey, lastGood, TtlSeconds);
+                return ToSet(lastGood);
+            }
+
+            return ToSet(Array.Empty<string>());
+        }
+    }
+
+    private static async Task<string[]> Fetch()
+    {
+        var names = new List<string>();
+        var start = "";
+
+        for (var page = 0; page < MaxPages; page++)
+        {
+            var result = await Rpc.Call("condenser_api", "get_following",
+                new JsonArray(Account, start, "ignore", PageSize));
+
+            if (result is not JsonArray rows || rows.Count == 0)
+            {
+                break;
+            }
+
+            var pageNames = ReadFollowing(rows);
+
+            // `start` is exclusive on Hive, so a page should not repeat the
+            // cursor. Drop it anyway: against a node treating it as inclusive
+            // this would re-append the same account until the page cap.
+            if (pageNames.Count > 0 && pageNames[0] == start)
+            {
+                pageNames.RemoveAt(0);
+            }
+
+            if (pageNames.Count == 0)
+            {
+                break;
+            }
+
+            names.AddRange(pageNames);
+
+            if (rows.Count < PageSize)
+            {
+                break;
+            }
+
+            start = pageNames[^1];
+        }
+
+        return names.ToArray();
+    }
+
+    internal static List<string> ReadFollowing(JsonArray rows)
+    {
+        var names = new List<string>();
+        foreach (var row in rows)
+        {
+            var name = row is JsonObject o && o.TryGetPropertyValue("following", out var f)
+                ? f?.GetValue<string>()
+                : null;
+            if (!string.IsNullOrEmpty(name))
+            {
+                names.Add(name);
+            }
+        }
+        return names;
+    }
+
+    internal static HashSet<string> ToSet(IEnumerable<string> names) =>
+        new(names, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Drop entries authored by a muted account. Returns a new array; entries
+    /// with no readable author are kept, since an unreadable shape is not
+    /// evidence of anything and dropping it would silently shrink the feed.
+    /// </summary>
+    public static JsonArray FilterMutedAuthors(JsonArray entries, ISet<string> muted)
+    {
+        if (muted.Count == 0)
+        {
+            return entries;
+        }
+
+        var kept = new JsonArray();
+        foreach (var entry in entries.ToArray())
+        {
+            var author = entry is JsonObject o && o.TryGetPropertyValue("author", out var a)
+                ? a?.GetValue<string>()
+                : null;
+
+            if (author != null && muted.Contains(author))
+            {
+                continue;
+            }
+
+            // A node can only live in one parent, and these come from a cache
+            // clone we own, so detach before re-parenting into the result.
+            entry?.Parent?.AsArray().Remove(entry);
+            kept.Add(entry);
+        }
+
+        return kept;
+    }
+}

--- a/dotnet/EcencyApi/Infrastructure/ModerationMutes.cs
+++ b/dotnet/EcencyApi/Infrastructure/ModerationMutes.cs
@@ -44,6 +44,14 @@ public static class ModerationMutes
     internal static HiveRpcClient Rpc = HiveClients.Default;
 
     /// <summary>
+    /// One refresh at a time. Without this, every request arriving after the TTL
+    /// lapses starts its own paging loop, so a burst turns one refresh into as
+    /// many RPC conversations as there are concurrent promoted-entries requests.
+    /// The waiters re-read the cache and take the winner's result.
+    /// </summary>
+    private static readonly SemaphoreSlim RefreshGate = new(1, 1);
+
+    /// <summary>
     /// The muted accounts, cached. Returns an empty set rather than throwing:
     /// a moderation filter that cannot load must not take a feed down with it.
     /// </summary>
@@ -55,27 +63,58 @@ public static class ModerationMutes
             return ToSet(cached);
         }
 
+        await RefreshGate.WaitAsync();
+        try
+        {
+            // Someone else may have refreshed while this request queued.
+            cached = MemCache.Get<string[]>(CacheKey);
+            if (cached != null)
+            {
+                return ToSet(cached);
+            }
+
+            return ToSet(await Refresh());
+        }
+        finally
+        {
+            RefreshGate.Release();
+        }
+    }
+
+    private static async Task<string[]> Refresh()
+    {
         try
         {
             var names = await Fetch();
             MemCache.Set(CacheKey, names, TtlSeconds);
-            MemCache.Set(LastGoodCacheKey, names);
-            return ToSet(names);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine($"warn: failed to fetch moderation mutes {e.Message}");
 
+            // Only a list with something in it is worth falling back to. An empty
+            // one is served live (unmuting everyone must take effect) but must not
+            // overwrite the fallback, or one empty answer would turn every later
+            // failure into no filtering at all.
+            if (names.Length > 0)
+            {
+                MemCache.Set(LastGoodCacheKey, names);
+            }
+
+            return names;
+        }
+        catch (Exception)
+        {
+            // Deliberately silent: this runs on the promoted-entries request path
+            // and the service keeps its logs quiet there (CLAUDE.md, "No hot-path
+            // logging"). The fallback below is what makes the failure survivable.
+            //
             // Re-arm the short TTL with the stale list so a node outage does not
             // put an RPC call on every promoted-entries request for its duration.
             var lastGood = MemCache.Get<string[]>(LastGoodCacheKey);
             if (lastGood != null)
             {
                 MemCache.Set(CacheKey, lastGood, TtlSeconds);
-                return ToSet(lastGood);
+                return lastGood;
             }
 
-            return ToSet(Array.Empty<string>());
+            return Array.Empty<string>();
         }
     }
 
@@ -86,10 +125,17 @@ public static class ModerationMutes
 
         for (var page = 0; page < MaxPages; page++)
         {
+            // Validate the shape at the client, so a node answering 200 with
+            // something that is not a row array fails over to another one and,
+            // if none can answer, throws. Without this an unusable answer read
+            // as "no more rows" and the caller cached an empty mute list --
+            // filtering silently off, with nothing anywhere saying so.
             var result = await Rpc.Call("condenser_api", "get_following",
-                new JsonArray(Account, start, "ignore", PageSize));
+                new JsonArray(Account, start, "ignore", PageSize),
+                validateResult: r => r is JsonArray);
 
-            if (result is not JsonArray rows || rows.Count == 0)
+            var rows = (JsonArray)result!;
+            if (rows.Count == 0)
             {
                 break;
             }
@@ -122,14 +168,26 @@ public static class ModerationMutes
         return names.ToArray();
     }
 
+    /// <summary>
+    /// Read one string property the lenient way. `GetValue&lt;string&gt;()` throws on
+    /// a lone-surrogate escape, which JSON.parse accepts and Hive nodes do emit;
+    /// letting that throw here would fail a promoted-entries request, or abort a
+    /// mute-list refresh, over one malformed account name.
+    /// </summary>
+    private static string? ReadString(JsonNode? owner, string property) =>
+        owner is JsonObject o
+        && o.TryGetPropertyValue(property, out var node)
+        && node is JsonValue value
+        && JsVal.TryGetStringLenient(value, out var s)
+            ? s
+            : null;
+
     internal static List<string> ReadFollowing(JsonArray rows)
     {
         var names = new List<string>();
         foreach (var row in rows)
         {
-            var name = row is JsonObject o && o.TryGetPropertyValue("following", out var f)
-                ? f?.GetValue<string>()
-                : null;
+            var name = ReadString(row, "following");
             if (!string.IsNullOrEmpty(name))
             {
                 names.Add(name);
@@ -156,9 +214,7 @@ public static class ModerationMutes
         var kept = new JsonArray();
         foreach (var entry in entries.ToArray())
         {
-            var author = entry is JsonObject o && o.TryGetPropertyValue("author", out var a)
-                ? a?.GetValue<string>()
-                : null;
+            var author = ReadString(entry, "author");
 
             if (author != null && muted.Contains(author))
             {


### PR DESCRIPTION
Follow-up from ecency/esync-py#28, which made the moderation account's on-chain mute list apply to every waves feed the indexer serves.

Promoted entries do not go through the indexer — they are served from here. That left a paid placement as the one surface a muted account could still reach an audience through, and the most prominent one in the feed.

## Change

`ModerationMutes` reads the list straight from chain (`condenser_api.get_following ... "ignore"`, paged, capped) rather than from another service, so it holds even when the indexer is behind. Cached 5 minutes: the list changes only when a moderator acts on it.

Degradation was the part worth designing:

- A failed refresh falls back to the last list seen, and re-arms the short TTL with it — so an unreachable node means slightly stale filtering rather than none, and does not put an RPC call on every request for the duration of the outage.
- With no list at all, the feed is served unfiltered rather than failing. A moderation filter that cannot load must not take the feed down with it.
- An entry with no readable author is kept. An unreadable shape is not evidence of anything, and dropping it would shrink the feed for a reason nobody could see.

The filter runs after the promoted cache is read, not before, so a new mute applies on the mute list's own refresh instead of waiting out the 5-minute promoted cache.

## Verification

Full suite green, 164 → 171 tests, no new warnings:

```
Passed!  - Failed: 0, Passed: 171, Skipped: 0, Total: 171
```

The 7 new tests cover the parts that can silently break a feed: an empty list leaves it untouched, matching is case-insensitive, order is preserved, an entry with no author survives, filtering everything yields an empty array rather than null, and the moderation account name is pinned (a typo there would read as "nobody is muted" with no error anywhere).

Beyond the unit tests, I ran the live fetch path once against real nodes with a throwaway harness (not committed), since the RPC envelope and paging are the parts unit tests cannot reach:

```
fetched 14: askrafiki, bilpcoinbpc, bpcvoter1, bpcvoter2, bpcvoter3, demo.account,
            gangstalking, hive.airdrops, hive.blog.reward, joythewanderer,
            kgakakillerg, networkallstar, sauyo, tkkg
second call 0.22ms, 14 names        <- served from cache, no second RPC
kept: good-karma                    <- hive.airdrops dropped from a two-entry feed
```

That matches the account's mute list on chain exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promoted posts are now filtered using Ecency’s moderation mute list.
  * Mute matching is case-insensitive, while entries without readable authors remain visible.
  * The moderation list refreshes automatically and retains the last known list when temporarily unavailable.

* **Bug Fixes**
  * Prevented muted authors’ promoted content from appearing in feeds.
  * Improved handling of empty, incomplete, malformed, or unavailable moderation data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->