### PR TITLE
rpc pool: drop hive-api.3speak.tv, which never completes a TCP connect

### DIFF
--- a/dotnet/EcencyApi.Tests/HiveRpcFailoverTests.cs
+++ b/dotnet/EcencyApi.Tests/HiveRpcFailoverTests.cs
@@ -474,8 +474,13 @@ public class HiveRpcFailoverTests
     [Fact]
     public void DefaultPool_DoesNotCarryTheUnreachableNode()
     {
+        // Nodes dropped for never completing a TCP connect. A node that answers
+        // nothing costs a full per-node timeout every time the ordering reaches
+        // it, which is every cold start and every lapsed park.
         Assert.DoesNotContain(HiveClients.DefaultNodes, n => n.Contains("arcange", StringComparison.Ordinal));
+        Assert.DoesNotContain(HiveClients.DefaultNodes, n => n.Contains("3speak", StringComparison.Ordinal));
         Assert.True(HiveClients.DefaultNodes.Count >= 6);
+        Assert.Equal(HiveClients.DefaultNodes.Count, HiveClients.DefaultNodes.Distinct().Count());
     }
 
     [Fact]

--- a/dotnet/EcencyApi/Infrastructure/HiveRpcClient.cs
+++ b/dotnet/EcencyApi/Infrastructure/HiveRpcClient.cs
@@ -434,16 +434,21 @@ public static class HiveClients
     // portfolio engine/chain layers came back empty for everyone. GetAccounts
     // also routes around such a node at runtime, but keeping them out of the pool
     // means correctness here does not depend on that fallback firing.
-    // hive-api.arcange.eu is absent too: it never completes a TCP connect from
-    // any host this service runs on (SYN, no answer), so every attempt cost the
-    // full per-node timeout and, in bursts, took every in-flight fill with it.
+    // hive-api.arcange.eu and hive-api.3speak.tv are absent for the same reason
+    // as each other: neither completes a TCP connect from any host this service
+    // runs on (SYN, no answer, on 443 and on 80), so every attempt cost the full
+    // per-node timeout and, in bursts, took every in-flight fill with it. A node
+    // that answers nothing is worse for the pool than a slow one, because the
+    // health tracker learns latency from answers and has none to learn from: it
+    // parks after three consecutive failures, the park lapses, it is probed
+    // again. While unparked it sits in config order, which is where any
+    // unproven latency profile starts.
     public static readonly IReadOnlyList<string> DefaultNodes = new[]
     {
         "https://api.hive.blog",
         "https://api.deathwing.me",
         "https://rpc.mahdiyari.info",
         "https://api.openhive.network",
-        "https://hive-api.3speak.tv",
         "https://api.syncad.com",
         "https://api.c0ff33a.uk",
     };


### PR DESCRIPTION
Closes #83.

`hive-api.3speak.tv` is in `HiveClients.DefaultNodes` but does not complete a TCP connect. DNS resolves, the connect never finishes, on 443 or on 80, so every attempt against it costs the full per-node timeout and returns nothing.

Re-checked before making the change, as the issue asks. From two hosts in different regions, three attempts each:

```
try1 code=000 connect=0.000000s total=10.002781s
try2 code=000 connect=0.000000s total=10.002220s
try3 code=000 connect=0.000000s total=10.002887s
```

`connect` never leaves 0 and every request ends at the `-m` ceiling.

## What changed

- Dropped the entry from `HiveClients.DefaultNodes`, folding the reason into the `hive-api.arcange.eu` note above the list, which was added for exactly this failure mode. No replacement node: the remaining public nodes we consider good are already in the pool, while the two others that are missing are missing for a correctness reason the same comment records.
- `DefaultPool_DoesNotCarryTheUnreachableNode` now asserts this host's absence next to arcange, plus that the pool has no duplicate entries. Mutation-checked: re-adding the node turns it red, so does duplicating any entry.

## Why it is worth a change rather than leaving it to the health tracker

The tracker does park a node after three consecutive failures, but parking is a recovery mechanism, not an exclusion. The park lapses, the node is probed again, then while unparked it sits in config order, which is exactly where an unproven latency profile starts. A node that answers nothing never produces a latency sample to rank on, so it keeps returning to the front of that list. Since `NodeHealthTracker` gained per-class latency profiles, there are now two profiles per node that can be unproven at once, so the cost of carrying a node that cannot answer is paid twice.
