### PR TITLE
fix(ai-image): forward the client's idempotency_key to the upstream

### DIFF
--- a/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
@@ -558,7 +558,9 @@ public static partial class PrivateApi
         {
             ["us"] = username,
         };
-        MiscCopyIfPresent(data, body, "prompt", "aspect_ratio", "power");
+        // idempotency_key lets a retry recover the same paid generation instead of
+        // charging a second one; the upstream validates its format itself.
+        MiscCopyIfPresent(data, body, "prompt", "aspect_ratio", "power", "idempotency_key");
         // AI image generation legitimately takes 10-60s+; keep it long.
         await Upstream.Pipe(
             ApiClient.ApiRequest("ai-image-generate", HttpMethod.Post, null, data, null, 120000), ctx);


### PR DESCRIPTION
Forward `idempotency_key` in `AiGenerateImage`, mirroring how `AiTranscribe` already carries it. The upstream validates the key format itself and uses it to replay a paid-but-undelivered generation on retry instead of creating (and charging) a new one.

Fixes #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image generation requests by forwarding the optional idempotency key, helping prevent duplicate processing when requests are retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->