### PR TITLE
feat(ai-image): expose the per-user generation history

### DIFF
--- a/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Misc.cs
@@ -566,6 +566,25 @@ public static partial class PrivateApi
             ApiClient.ApiRequest("ai-image-generate", HttpMethod.Post, null, data, null, 120000), ctx);
     }
 
+    /// <summary>
+    /// Per-user AI image generation history (the upstream's last 20 successful
+    /// generations). The username comes ONLY from the validated code: prompts are
+    /// private to their author, so a body-supplied username would let any caller
+    /// read someone else's generation history.
+    /// </summary>
+    public static async Task AiImagesHistory(HttpContext ctx)
+    {
+        var body = await ctx.ReadBody();
+        var username = await ValidateCode(body);
+        if (username == null)
+        {
+            await ctx.SendText(401, "Unauthorized");
+            return;
+        }
+        await Upstream.Pipe(
+            ApiClient.ApiRequest($"users/{username}/ai-images", HttpMethod.Get), ctx);
+    }
+
     public static async Task AiAssistPrice(HttpContext ctx)
     {
         var body = await ctx.ReadBody();

--- a/dotnet/EcencyApi/Handlers/Routes.cs
+++ b/dotnet/EcencyApi/Handlers/Routes.cs
@@ -155,6 +155,7 @@ public static partial class Routes
         app.MapPost("/private-api/boosted-post", PrivateApi.BoostedPost);
         app.MapPost("/private-api/ai-generate-price", PrivateApi.AiGeneratePrice);
         app.MapPost("/private-api/ai-generate-image", PrivateApi.AiGenerateImage);
+        app.MapPost("/private-api/ai-images", PrivateApi.AiImagesHistory);
         app.MapPost("/private-api/ai-assist-price", PrivateApi.AiAssistPrice);
         app.MapPost("/private-api/ai-assist", PrivateApi.AiAssist);
         app.MapPost("/private-api/ai-transcribe-price", PrivateApi.AiTranscribePrice);

--- a/dotnet/parity/driver.py
+++ b/dotnet/parity/driver.py
@@ -224,6 +224,13 @@ AI_TRANSCRIBE_DIVERGENCE = (
     "::pop and ::badcode for every POST route, which is why all three appear here."
 )
 
+AI_IMAGES_DIVERGENCE = (
+    "Per-user AI image history route added after the port (ePoints users/<u>/ai-images). "
+    "The reference build has no such route and answers 404; this one validates the "
+    "signed code and answers 401 or proxies the history. Deterministic and additive -- "
+    "no behavior the reference ever had is changing."
+)
+
 # Cases where the C# port intentionally differs from Node (Node bugs the port fixes).
 KNOWN_DIVERGENCES = {
     "/auth-api/hs-token-refresh::min":
@@ -256,6 +263,15 @@ KNOWN_DIVERGENCES = {
         AI_TRANSCRIBE_DIVERGENCE,
     "/private-api/ai-transcribe::badcode":
         AI_TRANSCRIBE_DIVERGENCE,
+    # Per-user AI image history, added after the port (ePoints users/<u>/ai-images).
+    # Same shape as the dictation entries: the reference build has no such route and
+    # answers 404 while this one validates the code and answers 401/proxies. Additive.
+    "/private-api/ai-images::min":
+        AI_IMAGES_DIVERGENCE,
+    "/private-api/ai-images::pop":
+        AI_IMAGES_DIVERGENCE,
+    "/private-api/ai-images::badcode":
+        AI_IMAGES_DIVERGENCE,
 }
 
 # Deliberately NOT listed above: /wallet-api/portfolio-v2::pop, whose HP action list


### PR DESCRIPTION
Adds `POST /private-api/ai-images`: validates the signed code and pipes the upstream per-user AI image history (`users/{username}/ai-images`) for the validated username only, mirroring the auth pattern of the other AI routes. Prompts are private to their author, so the username never comes from the request body.

Consumer: the AI dialog History tab in ecency/vision-web#1687.

Fixes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for retrieving AI image history.
  * Requests are validated before access is granted, with unauthorized requests receiving an appropriate error response.
  * Added support for submitting AI image history requests through the private API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->