### PR TITLE
Token validation refuses login-typed messages

### DIFF
--- a/dotnet/EcencyApi.Tests/TokenTypeTests.cs
+++ b/dotnet/EcencyApi.Tests/TokenTypeTests.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Nodes;
+using EcencyApi.Handlers;
+using Xunit;
+
+namespace EcencyApi.Tests;
+
+/// <summary>
+/// A HiveSigner-style message typed "login" proves who signed it and nothing
+/// more: HiveSigner answers /api/me for one and refuses it everywhere else, and
+/// the Ecency clients never send one (wallet logins send "code", HiveSigner
+/// issues "posting" for the scopes they request). Token validation refuses it
+/// before any key lookup, and leaves every other shape to the signature checks.
+/// </summary>
+public class TokenTypeTests
+{
+    private static JsonNode? Parse(string json) => JsonNode.Parse(json);
+
+    [Fact]
+    public void LoginTypedMessageIsRefused()
+    {
+        Assert.True(PrivateApi.IsLoginOnlyMessage(Parse("""{"type":"login","app":"ecency.app"}""")));
+        Assert.True(PrivateApi.IsLoginOnlyMessage(
+            Parse("""{"type":"login","app":"ecency.app","audience":"honeyback://hive"}""")));
+    }
+
+    [Theory]
+    [InlineData("""{"type":"code","app":"ecency.app"}""")]
+    [InlineData("""{"type":"posting","app":"ecency.app"}""")]
+    [InlineData("""{"type":"offline","app":"ecency.app"}""")]
+    [InlineData("""{"type":"refresh","app":"ecency.app"}""")]
+    [InlineData("""{"type":"Login","app":"ecency.app"}""")]
+    [InlineData("""{"app":"ecency.app"}""")]
+    [InlineData("""{"type":null}""")]
+    [InlineData("""{"type":1}""")]
+    [InlineData("""{"type":["login"]}""")]
+    [InlineData("""["login"]""")]
+    [InlineData("null")]
+    public void EverythingElseIsLeftToTheSignatureChecks(string signedMessage)
+    {
+        Assert.False(PrivateApi.IsLoginOnlyMessage(Parse(signedMessage)));
+    }
+}

--- a/dotnet/EcencyApi/Handlers/PrivateApi.Core.cs
+++ b/dotnet/EcencyApi/Handlers/PrivateApi.Core.cs
@@ -120,6 +120,15 @@ public static partial class PrivateApi
                 return null;
             }
 
+            // A message typed "login" only says who signed it. HiveSigner answers
+            // /api/me for one and refuses everything else, and no Ecency client
+            // ever sends one here, so it is not a session here either. Decided
+            // before any node lookup: the shape alone settles it.
+            if (IsLoginOnlyMessage(signedMessage))
+            {
+                return null;
+            }
+
             var currentTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
             // rawMessage = JSON.stringify({ signed_message, authors, timestamp })
@@ -191,6 +200,18 @@ public static partial class PrivateApi
             return null;
         }
     }
+
+    /// <summary>
+    /// True for a signed_message whose type is the string "login": a proof of
+    /// identity for another app, never a session. Anything else, including a
+    /// missing or non-string type, is left to the signature checks as before.
+    /// </summary>
+    internal static bool IsLoginOnlyMessage(JsonNode? signedMessage) =>
+        signedMessage is JsonObject obj
+        && obj.TryGetPropertyValue("type", out var typeNode)
+        && typeNode is JsonValue typeValue
+        && JsVal.TryGetStringLenient(typeValue, out var type)
+        && type == "login";
 
     /// <summary>key_auths.map(([key]) => key) — throws on non-array input like .map on a non-array.</summary>
     private static List<string?> MapKeyAuths(JsonNode? keyAuths)


### PR DESCRIPTION
## What

`ValidateCode` refuses a signed message whose `signed_message.type` is `login`, before any key lookup. Every other shape goes through the signature checks exactly as before.

A message typed `login` proves who signed it and nothing more: HiveSigner answers `/api/me` for one and refuses it at its token and broadcast routes. Ecency's own clients never send one here: wallet logins send `code`, and HiveSigner issues `posting` for the scopes the web and mobile apps request. Third-party login-scope tokens and the sign-in proof the mobile app now hands to other apps (ecency/vision-mobile#3544) are the only messages of that type, and neither should be a session on this API.

## Tests

`TokenTypeTests` pins the refusal (with and without an extra field in the message) and eleven shapes that stay with the signature checks: the other types, a differently-cased `Login`, a missing, null, numeric or array `type`, a non-object message. Disabling the check makes the first test fail. Full suite green locally on .NET 10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Login-only tokens are now rejected during validation, including messages with an audience.
  - Token validation now consistently excludes invalid, missing, or incorrectly formatted message types.
  - Other token types continue through the standard signature checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->